### PR TITLE
Add contributing guidelines for modes and MCPs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,4 +150,327 @@ Examples:
 - **Inspired by:** Teresa Torres's content research process
 - **Credit:** Based on Notion's documentation workflow
 
+---
+
+## Contributing Custom Modes
+
+Custom modes allow you to tailor Kilo Code's behavior for specific tasks or workflows. You can contribute modes that benefit the community.
+
+### Mode Requirements
+
+All contributed modes must:
+
+1. **Serve a clear purpose** - Optimized for specific tasks like documentation, testing, or security review
+2. **Be well-documented** - Include clear descriptions and use cases
+3. **Define appropriate permissions** - Use tool groups and file restrictions responsibly
+4. **Be tested** - Verify the mode works correctly in Kilo Code
+
+### Mode Structure
+
+Create a new folder with your mode name (use lowercase and hyphens):
+
+```
+modes/
+└── mode-name/
+    └── MODE.yaml
+```
+
+The `MODE.yaml` file should contain:
+
+```yaml
+id: mode-slug
+name: Mode Display Name
+description: Brief description of what this mode does
+author: "@your-github-username"
+tags: [relevant, tags, here]
+content: |
+  slug: mode-slug
+  name: 🎯 Mode Display Name
+  roleDefinition: |
+    You are a specialist in [domain]. Your expertise includes:
+    - Capability 1
+    - Capability 2
+    - Capability 3
+  groups:
+    - read
+    - edit
+    - command
+  customInstructions: |
+    Specific behavioral guidelines for this mode.
+```
+
+### Mode Properties
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `id` | Yes | Unique identifier (kebab-case) |
+| `name` | Yes | Display name shown in the marketplace |
+| `description` | Yes | Brief description of the mode's purpose |
+| `author` | Yes | Your GitHub username with @ prefix |
+| `tags` | Yes | Array of relevant tags for discovery |
+| `content.slug` | Yes | Internal identifier (must match `id`) |
+| `content.name` | Yes | Display name with optional emoji |
+| `content.roleDefinition` | Yes | Defines the mode's expertise and personality |
+| `content.groups` | Yes | Tool groups the mode can access |
+| `content.customInstructions` | No | Additional behavioral guidelines |
+| `content.whenToUse` | No | Guidance for automated mode selection |
+
+### Available Tool Groups
+
+- `read` - Read files and explore the codebase
+- `edit` - Modify files (can include file restrictions)
+- `command` - Execute terminal commands
+- `browser` - Browser automation capabilities
+- `mcp` - Access MCP server tools
+
+### File Restrictions Example
+
+To restrict which files a mode can edit:
+
+```yaml
+groups:
+  - read
+  - - edit
+    - fileRegex: \.(md|mdx)$
+      description: Markdown files only
+  - command
+```
+
+### Mode Examples
+
+**Documentation Writer** (`modes/docs-writer/MODE.yaml`):
+```yaml
+id: docs-writer
+name: Documentation Writer
+description: Technical documentation expert for clear, comprehensive docs
+author: "@your-username"
+tags: [documentation, markdown, technical-writing]
+content: |
+  slug: docs-writer
+  name: 📝 Documentation Writer
+  roleDefinition: |
+    You are a technical writer specializing in clear documentation.
+  groups:
+    - read
+    - - edit
+      - fileRegex: \.md$
+        description: Markdown files only
+  customInstructions: |
+    Focus on clarity, proper formatting, and comprehensive examples.
+```
+
+**Security Reviewer** (`modes/security-review/MODE.yaml`):
+```yaml
+id: security-review
+name: Security Reviewer
+description: Read-only security analysis and vulnerability assessment
+author: "@your-username"
+tags: [security, audit, code-review]
+content: |
+  slug: security-review
+  name: 🔒 Security Reviewer
+  roleDefinition: |
+    You are a security specialist reviewing code for vulnerabilities.
+  groups:
+    - read
+    - browser
+  customInstructions: |
+    Focus on input validation, authentication flaws, and data exposure risks.
+```
+
+---
+
+## Contributing MCP Servers
+
+MCP (Model Context Protocol) servers extend Kilo Code's capabilities by connecting to external tools and services.
+
+### MCP Requirements
+
+All contributed MCP servers must:
+
+1. **Provide real value** - Connect to useful external services or tools
+2. **Be well-documented** - Include clear setup instructions and prerequisites
+3. **Handle authentication securely** - Use environment variables for sensitive data
+4. **Include multiple installation options** - When possible, provide NPX, Docker, and other methods
+
+### MCP Structure
+
+Create a new folder with your MCP server name (use lowercase and hyphens):
+
+```
+mcps/
+└── service-name/
+    └── MCP.yaml
+```
+
+The `MCP.yaml` file should contain:
+
+```yaml
+id: service-name
+name: Service Name
+description: Brief description of what this MCP server provides
+author: author-name
+url: https://github.com/org/repo
+tags:
+  - relevant
+  - tags
+  - here
+prerequisites:
+  - Required software or accounts
+content:
+  - name: NPX
+    prerequisites:
+      - Node.js
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "@package/mcp-server"],
+        "env": {
+          "API_KEY": "{{API_KEY}}"
+        }
+      }
+parameters:
+  - name: API Key
+    key: API_KEY
+    placeholder: your_api_key_here
+```
+
+### MCP Properties
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `id` | Yes | Unique identifier (kebab-case) |
+| `name` | Yes | Display name for the MCP server |
+| `description` | Yes | Clear description of capabilities |
+| `author` | Yes | Author or organization name |
+| `url` | Yes | Link to the MCP server repository |
+| `tags` | Yes | Array of relevant tags |
+| `prerequisites` | No | Required software or accounts |
+| `content` | Yes | Installation configuration(s) |
+| `parameters` | No | User-configurable parameters |
+
+### Transport Types
+
+**STDIO Transport (Local):**
+```yaml
+content: |
+  {
+    "command": "npx",
+    "args": ["-y", "@package/mcp-server"],
+    "env": {
+      "API_KEY": "{{API_KEY}}"
+    }
+  }
+```
+
+**Streamable HTTP Transport (Remote):**
+```yaml
+content: |
+  {
+    "type": "streamable-http",
+    "url": "https://your-server-url.com/mcp",
+    "headers": {
+      "Authorization": "Bearer {{API_TOKEN}}"
+    }
+  }
+```
+
+### Multiple Installation Options
+
+Provide multiple ways to install when possible:
+
+```yaml
+content:
+  - name: NPX
+    prerequisites:
+      - Node.js
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "@package/mcp-server"]
+      }
+  - name: Docker
+    prerequisites:
+      - Docker
+    content: |
+      {
+        "command": "docker",
+        "args": ["run", "-i", "--rm", "mcp/server"]
+      }
+  - name: UVX
+    prerequisites:
+      - Python and uv
+    content: |
+      {
+        "command": "uvx",
+        "args": ["mcp-server-package"]
+      }
+```
+
+### Parameter Configuration
+
+Define user-configurable parameters:
+
+```yaml
+parameters:
+  - name: API Key
+    key: API_KEY
+    placeholder: your_api_key_here
+  - name: Optional Setting
+    key: OPTIONAL_SETTING
+    placeholder: default_value
+    optional: true
+```
+
+### MCP Example
+
+**Example Service** (`mcps/example-service/MCP.yaml`):
+
+```yaml
+id: example-service
+name: Example Service
+description: Enables AI assistants to interact with Example Service API for data retrieval and automation.
+author: example-org
+url: https://github.com/example-org/example-mcp
+tags:
+  - api-integration
+  - automation
+  - data-retrieval
+prerequisites:
+  - Example Service account
+content:
+  - name: NPX
+    prerequisites:
+      - Node.js
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "@example/mcp-server"],
+        "env": {
+          "EXAMPLE_API_KEY": "{{EXAMPLE_API_KEY}}"
+        }
+      }
+  - name: Docker
+    prerequisites:
+      - Docker
+    content: |
+      {
+        "command": "docker",
+        "args": ["run", "-i", "--rm", "-e", "EXAMPLE_API_KEY", "example/mcp-server"],
+        "env": {
+          "EXAMPLE_API_KEY": "{{EXAMPLE_API_KEY}}"
+        }
+      }
+parameters:
+  - name: Example API Key
+    key: EXAMPLE_API_KEY
+    placeholder: your_example_api_key
+```
+
+---
+
+## Questions?
+
+Open an issue if you have questions about contributing or need help structuring your skill, mode, or MCP server.
+
 Thank you for contributing to Kilo Marketplace!


### PR DESCRIPTION
Adds CONTRIBUTING guidance for contributing custom Modes and MCP servers.

- Modes live in per-mode folders as `modes/<slug>/MODE.yaml`
- MCPs live in per-server folders as `mcps/<id>/MCP.yaml`
- These entries are merged into `modes/marketplace.yaml` and `mcps/marketplace.yaml`
