### PR TITLE
Update GMP Code Assist MCP to Streamable HTTP endpoint

### DIFF
--- a/mcps/google-maps-platform-code-assist/MCP.yaml
+++ b/mcps/google-maps-platform-code-assist/MCP.yaml
@@ -15,11 +15,16 @@ tags:
   - ai-assistant
   - official
 content:
-  - name: NPX
-    prerequisites:
-      - Node.js
+  - name: Kilo Code (Streamable HTTP)
+    prerequisites: []
     content: |
       {
-        "command": "npx",
-        "args": ["-y", "@googlemaps/code-assist-mcp@0.2.0"]
+        "httpUrl": "https://mapscodeassist.googleapis.com/mcp"
+      }
+  - name: Kilo CLI (Remote)
+    prerequisites: []
+    content: |
+      {
+        "type": "remote",
+        "url": "https://mapscodeassist.googleapis.com/mcp"
       }


### PR DESCRIPTION
Updates the Google Maps Platform Code Assist MCP to use the new Streamable HTTP endpoint configuration.

Provides support for both:
- **Kilo Code** (`httpUrl`) as per [Kilo Code Server Transports](https://kilo.ai/docs/automate/mcp/server-transports)
- **Kilo CLI** (`type: remote`) as per [Kilo CLI Usage](https://kilo.ai/docs/automate/mcp/using-in-cli)