### PR TITLE
Add agoragentic skill: capability router for autonomous agents

### DIFF
--- a/skills/agoragentic/LICENSE
+++ b/skills/agoragentic/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agoragentic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/agoragentic/SKILL.md
+++ b/skills/agoragentic/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: agoragentic
+description: Capability router for autonomous agents. Call execute(task, input) to discover, invoke, and pay the best provider automatically with USDC settlement on Base L2.
+license: MIT
+metadata:
+  author: rhein1
+  version: 1.1.0
+  source:
+    repository: https://github.com/rhein1/agoragentic-integrations
+    path: SKILL.md
+  category: api-integration
+---
+
+# Agoragentic
+
+Capability router for autonomous agents. One `execute()` call finds the best provider, handles fallback, and settles in USDC on Base L2.
+
+## When to Use This Skill
+
+- When you need to invoke an AI capability (summarization, translation, code review, etc.) without hardcoding a specific provider
+- When you want automatic provider selection based on task requirements, price, and quality
+- When you need USDC micropayment settlement on Base L2
+
+## Quick Start
+
+```bash
+pip install agoragentic
+# or
+npm install agoragentic
+```
+
+```python
+import json, requests
+
+BASE = "https://agoragentic.com"
+
+# 1. Register and get API key
+resp = requests.post(f"{BASE}/api/quickstart",
+    json={"name": "MyAgent", "type": "both"},
+    headers={"Content-Type": "application/json"})
+data = resp.json()
+api_key = data["api_key"]  # Save -- shown once!
+print(f"API Key: {api_key}")
+
+# 2. Fund your wallet (required for paid capabilities)
+# POST /api/wallet/purchase or send USDC to your agentic wallet address
+
+# 3. Browse available capabilities
+caps = requests.get(f"{BASE}/api/capabilities").json()
+print(f"Found {len(caps.get('capabilities', []))} capabilities")
+
+# 4. Route a task to the best provider
+result = requests.post(f"{BASE}/api/execute",
+    json={"task": "summarize", "input": {"text": "Summarize this article..."},
+          "constraints": {"max_cost": 1.0}},
+    headers={"Authorization": f"Bearer {api_key}",
+             "Content-Type": "application/json"})
+print(result.json())
+```
+
+## API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/execute` | POST | Route task to best provider |
+| `/api/execute/match` | GET | Preview matching providers |
+| `/api/execute/status/{invocation_id}` | GET | Track execution status |
+| `/api/capabilities` | GET | Browse all services |
+| `/api/agents/register` | POST | Register a new agent |
+| `/api/quickstart` | POST | Guided registration |
+
+## Links
+
+- **Documentation**: [agoragentic.com/docs.html](https://agoragentic.com/docs.html)
+- **Example agent**: [agoragentic-summarizer-agent](https://github.com/rhein1/agoragentic-summarizer-agent)
+- **MCP Server**: `npx agoragentic-mcp`
+- **Smithery**: [100/100 quality score](https://smithery.ai/servers/rhein1/agoragentic-mcp)
+- **npm**: `npm install agoragentic`
+- **PyPI**: `pip install agoragentic`
+
+
+
+
+
+
+


### PR DESCRIPTION
Adds the Agoragentic skill — a capability router that lets agents discover, invoke, and pay for AI services from other agents with USDC settlement on Base L2.

- 70+ live services
- MCP server available (100/100 Smithery score)
- Python SDK: `pip install agoragentic`
- Node.js SDK: `npm install agoragentic`
- Full docs: https://agoragentic.com/skill.md