### PR TITLE
Add license_path to source metadata

### DIFF
--- a/bin/update-skills.ts
+++ b/bin/update-skills.ts
@@ -25,6 +25,7 @@ const skillsDir = path.join(__dirname, "..", "skills");
 interface SourceInfo {
   repository: string;
   path: string;
+  license_path?: string;
 }
 
 interface SkillInfo {
@@ -70,7 +71,7 @@ function collectSkills(filter?: string[]): SkillInfo[] {
     skills.push({
       name: dir.name,
       dir: path.join(skillsDir, dir.name),
-      source: { repository: source.repository, path: source.path },
+      source: { repository: source.repository, path: source.path, license_path: source.license_path },
       frontmatter,
     });
   }
@@ -188,6 +189,7 @@ function updateFromRepo(repoUrl: string, skills: SkillInfo[]): void {
       newFrontmatter.metadata.source = {
         repository: skill.source.repository,
         path: skill.source.path,
+        ...(skill.source.license_path && { license_path: skill.source.license_path }),
       };
 
       const updatedContent = matter.stringify(body, newFrontmatter);

--- a/skills/agent-md-refactor/SKILL.md
+++ b/skills/agent-md-refactor/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   source:
     repository: https://github.com/softaworks/agent-toolkit
     path: skills/agent-md-refactor
+    license_path: LICENSE
 ---
 
 # Agent MD Refactor


### PR DESCRIPTION
## Summary

- Adds optional `license_path` field to `metadata.source` in skill frontmatter, pointing to the license file relative to the repository root
- Updates `bin/update-skills.ts` to preserve `license_path` when syncing a skill from upstream
- Adds `license_path: LICENSE` to `skills/agent-md-refactor/SKILL.md` as the first usage