### PR TITLE
Add license_path to source metadata for skills with LICENSE files

### DIFF
--- a/skills/artifacts-builder/SKILL.md
+++ b/skills/artifacts-builder/SKILL.md
@@ -11,6 +11,7 @@ metadata:
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: artifacts-builder
+    license_path: artifacts-builder/LICENSE.txt
 ---
 
 # Artifacts Builder

--- a/skills/canvas-design/SKILL.md
+++ b/skills/canvas-design/SKILL.md
@@ -11,6 +11,7 @@ metadata:
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: canvas-design
+    license_path: canvas-design/LICENSE.txt
 ---
 
 These are instructions for creating design philosophies - aesthetic movements that are then EXPRESSED VISUALLY. Output only .md files, .pdf files, and .png files.

--- a/skills/figma-implement-design/SKILL.md
+++ b/skills/figma-implement-design/SKILL.md
@@ -8,6 +8,7 @@ metadata:
   source:
     repository: https://github.com/openai/skills
     path: skills/.curated/figma-implement-design
+    license_path: skills/.curated/figma-implement-design/LICENSE.txt
 ---
 
 

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   source:
     repository: https://github.com/anthropics/skills
     path: skills/frontend-design
+    license_path: skills/frontend-design/LICENSE.txt
 ---
 
 This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.

--- a/skills/internal-comms/SKILL.md
+++ b/skills/internal-comms/SKILL.md
@@ -12,6 +12,7 @@ metadata:
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: internal-comms
+    license_path: internal-comms/LICENSE.txt
 ---
 
 ## When to use this skill

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -11,6 +11,7 @@ metadata:
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: mcp-builder
+    license_path: mcp-builder/LICENSE.txt
 ---
 
 # MCP Server Development Guide

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -10,6 +10,7 @@ metadata:
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: skill-creator
+    license_path: skill-creator/LICENSE.txt
 ---
 
 # Skill Creator

--- a/skills/slack-gif-creator/SKILL.md
+++ b/skills/slack-gif-creator/SKILL.md
@@ -11,6 +11,7 @@ metadata:
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: slack-gif-creator
+    license_path: slack-gif-creator/LICENSE.txt
 ---
 
 # Slack GIF Creator - Flexible Toolkit

--- a/skills/theme-factory/SKILL.md
+++ b/skills/theme-factory/SKILL.md
@@ -11,6 +11,7 @@ metadata:
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: theme-factory
+    license_path: theme-factory/LICENSE.txt
 ---
 
 

--- a/skills/webapp-testing/SKILL.md
+++ b/skills/webapp-testing/SKILL.md
@@ -10,6 +10,7 @@ metadata:
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: webapp-testing
+    license_path: webapp-testing/LICENSE.txt
 ---
 
 # Web Application Testing


### PR DESCRIPTION
## Summary

- Add `license_path` to `metadata.source` in SKILL.md for all 10 skills that have LICENSE files but were missing this field
- Each `license_path` was verified against the actual source repository to ensure correctness
- Verified that running `bin/update-skills.ts` preserves the `license_path` values and does not remove LICENSE files

### Skills updated

| Skill | Source Repo | `license_path` |
|---|---|---|
| `frontend-design` | anthropics/skills | `skills/frontend-design/LICENSE.txt` |
| `figma-implement-design` | openai/skills | `skills/.curated/figma-implement-design/LICENSE.txt` |
| `artifacts-builder` | ComposioHQ/awesome-claude-skills | `artifacts-builder/LICENSE.txt` |
| `canvas-design` | ComposioHQ/awesome-claude-skills | `canvas-design/LICENSE.txt` |
| `internal-comms` | ComposioHQ/awesome-claude-skills | `internal-comms/LICENSE.txt` |
| `mcp-builder` | ComposioHQ/awesome-claude-skills | `mcp-builder/LICENSE.txt` |
| `skill-creator` | ComposioHQ/awesome-claude-skills | `skill-creator/LICENSE.txt` |
| `slack-gif-creator` | ComposioHQ/awesome-claude-skills | `slack-gif-creator/LICENSE.txt` |
| `theme-factory` | ComposioHQ/awesome-claude-skills | `theme-factory/LICENSE.txt` |
| `webapp-testing` | ComposioHQ/awesome-claude-skills | `webapp-testing/LICENSE.txt` |

`vercel-deploy` was skipped — its upstream path returns 404 and no LICENSE exists in the remote repo.
