### PR TITLE
feat: add KCP MCP server (289 CLI manifests, ~33% context savings)

### DIFF
--- a/mcps/kcp-mcp/MCP.yaml
+++ b/mcps/kcp-mcp/MCP.yaml
@@ -38,5 +38,5 @@ content:
 parameters:
   - name: Custom Manifests Directory
     key: COMMANDS_DIR
-    description: Absolute path to a directory containing your own KCP YAML manifests (e.g. ~/.kcp/commands). Only required when using the "Local (with custom manifest directory)" configuration.
+    description: Absolute path to a directory containing kcp-commands YAML manifests (see github.com/Cantara/kcp-commands for the format). Only required when using the "Local (with custom manifest directory)" option.
     placeholder: ~/.kcp/commands

--- a/mcps/kcp-mcp/MCP.yaml
+++ b/mcps/kcp-mcp/MCP.yaml
@@ -32,6 +32,10 @@ content:
     content: |
       {
         "command": "npx",
-        "args": ["-y", "kcp-mcp", "--commands-dir", "/path/to/custom/manifests"],
+        "args": ["-y", "kcp-mcp", "--commands-dir", "{{COMMANDS_DIR}}"],
         "env": {}
       }
+parameters:
+  - name: Custom Manifests Directory
+    key: COMMANDS_DIR
+    placeholder: /path/to/custom/manifests

--- a/mcps/kcp-mcp/MCP.yaml
+++ b/mcps/kcp-mcp/MCP.yaml
@@ -17,16 +17,16 @@ tags:
 prerequisites:
   - Node.js 18+
 content:
-  - name: NPX
+  - name: NPX (with knowledge.yaml path)
     prerequisites:
       - Node.js 18+
     content: |
       {
         "command": "npx",
-        "args": ["-y", "kcp-mcp"],
+        "args": ["-y", "kcp-mcp", "{{KNOWLEDGE_YAML_PATH}}"],
         "env": {}
       }
-  - name: Local (with custom manifest directory)
+  - name: Local (with custom kcp-commands directory)
     prerequisites:
       - Node.js 18+
     content: |
@@ -36,7 +36,11 @@ content:
         "env": {}
       }
 parameters:
-  - name: Custom Manifests Directory
+  - name: Knowledge YAML Path
+    key: KNOWLEDGE_YAML_PATH
+    description: Absolute path to your project knowledge.yaml manifest file. The server reads this to expose structured knowledge as MCP resources. MCP clients do not guarantee cwd, so an absolute path is required.
+    placeholder: /absolute/path/to/your/project/knowledge.yaml
+  - name: Custom Commands Directory
     key: COMMANDS_DIR
-    description: Absolute path to a directory containing kcp-commands YAML manifests (see github.com/Cantara/kcp-commands for the format). Only required when using the "Local (with custom manifest directory)" option.
+    description: Absolute path to a directory containing kcp-commands YAML manifests (see github.com/Cantara/kcp-commands for the format). Only required when using the "Local (with custom kcp-commands directory)" option.
     placeholder: ~/.kcp/commands

--- a/mcps/kcp-mcp/MCP.yaml
+++ b/mcps/kcp-mcp/MCP.yaml
@@ -1,0 +1,37 @@
+id: kcp-mcp
+name: KCP — Knowledge Context Protocol
+description: |
+  Exposes typed capability manifests (KCP) as MCP resources. Gives agents structured
+  knowledge of CLI tools, APIs, and services — what they do, what flags matter, what
+  output to expect — reducing context window waste by ~33% in CLI-heavy sessions.
+  289 bundled manifests covering git, docker, kubectl, npm, aws, terraform, and more.
+author: totto
+url: https://github.com/Cantara/knowledge-context-protocol
+tags:
+  - knowledge
+  - context
+  - cli-tools
+  - token-efficiency
+  - manifests
+  - kcp
+prerequisites:
+  - Node.js 18+
+content:
+  - name: NPX
+    prerequisites:
+      - Node.js 18+
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "kcp-mcp"],
+        "env": {}
+      }
+  - name: Local (with custom manifest directory)
+    prerequisites:
+      - Node.js 18+
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "kcp-mcp", "--commands-dir", "/path/to/custom/manifests"],
+        "env": {}
+      }

--- a/mcps/kcp-mcp/MCP.yaml
+++ b/mcps/kcp-mcp/MCP.yaml
@@ -38,4 +38,5 @@ content:
 parameters:
   - name: Custom Manifests Directory
     key: COMMANDS_DIR
-    placeholder: /path/to/custom/manifests
+    description: Absolute path to a directory containing your own KCP YAML manifests (e.g. ~/.kcp/commands). Only required when using the "Local (with custom manifest directory)" configuration.
+    placeholder: ~/.kcp/commands

--- a/mcps/kcp-mcp/MCP.yaml
+++ b/mcps/kcp-mcp/MCP.yaml
@@ -32,7 +32,7 @@ content:
     content: |
       {
         "command": "npx",
-        "args": ["-y", "kcp-mcp", "--commands-dir", "{{COMMANDS_DIR}}"],
+        "args": ["-y", "kcp-mcp", "{{KNOWLEDGE_YAML_PATH}}", "--commands-dir", "{{COMMANDS_DIR}}"],
         "env": {}
       }
 parameters:
@@ -43,4 +43,4 @@ parameters:
   - name: Custom Commands Directory
     key: COMMANDS_DIR
     description: Absolute path to a directory containing kcp-commands YAML manifests (see github.com/Cantara/kcp-commands for the format). Only required when using the "Local (with custom kcp-commands directory)" option.
-    placeholder: ~/.kcp/commands
+    placeholder: /home/youruser/.kcp/commands


### PR DESCRIPTION
## What this adds

KCP (Knowledge Context Protocol) MCP server — exposes typed capability manifests for 289 CLI tools as MCP resources. Agents query the manifest index to get structured knowledge of what a command does, what flags exist, and what output patterns to expect — before executing it.

## Why it's useful for Kilo users

CLI-heavy agentic sessions waste 20–40% of the context window on `--help` calls and noisy output. kcp-mcp gives the agent structured knowledge upfront:

- **~33% context window reduction** (67,352 tokens saved in measured sessions)
- **98% reduction** on high-noise commands (`ps aux`: 30,828 → 652 tokens after filter)
- **73–80% fewer tool calls** in explore-heavy sessions

289 manifests covering: git, docker, kubectl, npm/yarn/bun/pnpm, aws/gcloud/az, terraform, python, java, cargo, maven/gradle, psql/mysql, and 200+ more.

## Links

- npm: https://www.npmjs.com/package/kcp-mcp (v0.12.0)
- Source: https://github.com/Cantara/knowledge-context-protocol/tree/main/bridge/typescript
- Manifests (Apache 2.0): https://github.com/Cantara/kcp-commands
- KCP spec: https://github.com/Cantara/knowledge-context-protocol

No API key or account required. Works out of the box with `npx kcp-mcp`.