### PR TITLE
Fix update-skills to fetch and copy LICENSE via license_path

### DIFF
--- a/bin/update-skills.ts
+++ b/bin/update-skills.ts
@@ -114,14 +114,20 @@ function updateFromRepo(repoUrl: string, skills: SkillInfo[]): void {
       stdio: "pipe",
     });
 
-    // Write all skill paths into the sparse-checkout file
+    // Write all skill paths (and any license paths) into the sparse-checkout file
     const sparseCheckoutFile = path.join(
       tempDir,
       ".git",
       "info",
       "sparse-checkout",
     );
-    const paths = skills.map((s) => s.source.path).join("\n") + "\n";
+    const pathSet = new Set(skills.map((s) => s.source.path));
+    for (const s of skills) {
+      if (s.source.license_path) {
+        pathSet.add(s.source.license_path);
+      }
+    }
+    const paths = [...pathSet].join("\n") + "\n";
     fs.writeFileSync(sparseCheckoutFile, paths);
 
     // Fetch and checkout
@@ -194,6 +200,19 @@ function updateFromRepo(repoUrl: string, skills: SkillInfo[]): void {
 
       const updatedContent = matter.stringify(body, newFrontmatter);
       fs.writeFileSync(newSkillMdPath, updatedContent);
+
+      // Copy LICENSE from the configured license_path (repo-root-relative) if it exists
+      if (skill.source.license_path) {
+        const licenseSrc = path.join(tempDir, skill.source.license_path);
+        if (fs.existsSync(licenseSrc)) {
+          const licenseDest = path.join(skill.dir, "LICENSE");
+          fs.copyFileSync(licenseSrc, licenseDest);
+        } else {
+          console.warn(
+            `  ⚠ ${skill.name}: license_path "${skill.source.license_path}" not found in ${repoUrl}`,
+          );
+        }
+      }
 
       console.log(`  ✓ ${skill.name}`);
     }

--- a/skills/agent-md-refactor/LICENSE
+++ b/skills/agent-md-refactor/LICENSE
@@ -1,7 +1,21 @@
-Copyright © 2026 softaworks
+MIT License
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2026 Leonardo Flores
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/agent-md-refactor/SKILL.md
+++ b/skills/agent-md-refactor/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: agent-md-refactor
-description: Refactor bloated AGENTS.md, CLAUDE.md, or similar agent instruction files to follow progressive disclosure principles. Splits monolithic files into organized, linked documentation.
+description: >-
+  Refactor bloated AGENTS.md, CLAUDE.md, or similar agent instruction files to
+  follow progressive disclosure principles. Splits monolithic files into
+  organized, linked documentation.
 license: MIT
 metadata:
   category: development
   source:
-    repository: https://github.com/softaworks/agent-toolkit
+    repository: 'https://github.com/softaworks/agent-toolkit'
     path: skills/agent-md-refactor
     license_path: LICENSE
 ---


### PR DESCRIPTION
## Summary

- Fix `bin/update-skills.ts` to actually use the `license_path` field from skill source metadata
- Include `license_path` entries in the git sparse checkout so LICENSE files at the repo root are fetched
- Copy the LICENSE file into the skill directory after updating from upstream

Previously, `license_path` was stored in frontmatter but never acted upon — the sparse checkout only fetched the skill subdirectory path, so repo-root LICENSE files were silently dropped on every update.
