### PR TITLE
Fix license_path for angular skills and preserve local licenses during updates

### DIFF
--- a/bin/update-skills.ts
+++ b/bin/update-skills.ts
@@ -157,6 +157,17 @@ function updateFromRepo(repoUrl: string, skills: SkillInfo[]): void {
         continue;
       }
 
+      // Save any existing local LICENSE file before we wipe the directory,
+      // so we can restore it if the upstream doesn't provide one.
+      let savedLicense: { name: string; content: Buffer } | null = null;
+      for (const licenseName of ["LICENSE", "LICENSE.txt"]) {
+        const licensePath = path.join(skill.dir, licenseName);
+        if (fs.existsSync(licensePath)) {
+          savedLicense = { name: licenseName, content: fs.readFileSync(licensePath) };
+          break;
+        }
+      }
+
       // Remove current skill contents (except .git artifacts, if any)
       const existingEntries = fs.readdirSync(skill.dir);
       for (const entry of existingEntries) {
@@ -212,6 +223,17 @@ function updateFromRepo(repoUrl: string, skills: SkillInfo[]): void {
             `  ⚠ ${skill.name}: license_path "${skill.source.license_path}" not found in ${repoUrl}`,
           );
         }
+      }
+
+      // If no LICENSE file ended up in the skill dir (neither from upstream
+      // nor from license_path), restore the previously saved local one.
+      const hasLicense = fs.existsSync(path.join(skill.dir, "LICENSE"))
+        || fs.existsSync(path.join(skill.dir, "LICENSE.txt"));
+      if (!hasLicense && savedLicense) {
+        fs.writeFileSync(
+          path.join(skill.dir, savedLicense.name),
+          savedLicense.content,
+        );
       }
 
       console.log(`  ✓ ${skill.name}`);

--- a/skills/angular-component/SKILL.md
+++ b/skills/angular-component/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: angular-component
 description: Create modern Angular standalone components following v20+ best practices. Use for building UI components with signal-based inputs/outputs, OnPush change detection, host bindings, content projection, and lifecycle hooks. Triggers on component creation, refactoring class-based inputs to signals, adding host bindings, or implementing accessible interactive components.
-license: Complete terms in LICENSE.txt
+license: MIT
 metadata:
   category: development
   source:
     repository: https://github.com/analogjs/angular-skills
     path: skills/angular-component
+    license_path: LICENSE
 ---
 
 # Angular Component

--- a/skills/angular-di/SKILL.md
+++ b/skills/angular-di/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: angular-di
 description: Implement dependency injection in Angular v20+ using inject(), injection tokens, and provider configuration. Use for service architecture, providing dependencies at different levels, creating injectable tokens, and managing singleton vs scoped services. Triggers on service creation, configuring providers, using injection tokens, or understanding DI hierarchy.
-license: Complete terms in LICENSE.txt
+license: MIT
 metadata:
   category: development
   source:
     repository: https://github.com/analogjs/angular-skills
     path: skills/angular-di
+    license_path: LICENSE
 ---
 
 # Angular Dependency Injection

--- a/skills/angular-directives/SKILL.md
+++ b/skills/angular-directives/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: angular-directives
 description: Create custom directives in Angular v20+ for DOM manipulation and behavior extension. Use for attribute directives that modify element behavior/appearance, structural directives for portals/overlays, and host directives for composition. Triggers on creating reusable DOM behaviors, extending element functionality, or composing behaviors across components. Note - use native @if/@for/@switch for control flow, not custom structural directives.
-license: Complete terms in LICENSE.txt
+license: MIT
 metadata:
   category: development
   source:
     repository: https://github.com/analogjs/angular-skills
     path: skills/angular-directives
+    license_path: LICENSE
 ---
 
 # Angular Directives

--- a/skills/angular-forms/SKILL.md
+++ b/skills/angular-forms/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: angular-forms
 description: Build signal-based forms in Angular v21+ using the new Signal Forms API. Use for form creation with automatic two-way binding, schema-based validation, field state management, and dynamic forms. Triggers on form implementation, adding validation, creating multi-step forms, or building forms with conditional fields. Signal Forms are experimental but recommended for new Angular projects.
-license: Complete terms in LICENSE.txt
+license: MIT
 metadata:
   category: development
   source:
     repository: https://github.com/analogjs/angular-skills
     path: skills/angular-forms
+    license_path: LICENSE
 ---
 
 # Angular Signal Forms

--- a/skills/angular-http/SKILL.md
+++ b/skills/angular-http/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: angular-http
 description: Implement HTTP data fetching in Angular v20+ using resource(), httpResource(), and HttpClient. Use for API calls, data loading with signals, request/response handling, and interceptors. Triggers on data fetching, API integration, loading states, error handling, or converting Observable-based HTTP to signal-based patterns.
-license: Complete terms in LICENSE.txt
+license: MIT
 metadata:
   category: development
   source:
     repository: https://github.com/analogjs/angular-skills
     path: skills/angular-http
+    license_path: LICENSE
 ---
 
 # Angular HTTP & Data Fetching

--- a/skills/angular-routing/SKILL.md
+++ b/skills/angular-routing/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: angular-routing
 description: Implement routing in Angular v20+ applications with lazy loading, functional guards, resolvers, and route parameters. Use for navigation setup, protected routes, route-based data loading, and nested routing. Triggers on route configuration, adding authentication guards, implementing lazy loading, or reading route parameters with signals.
-license: Complete terms in LICENSE.txt
+license: MIT
 metadata:
   category: development
   source:
     repository: https://github.com/analogjs/angular-skills
     path: skills/angular-routing
+    license_path: LICENSE
 ---
 
 # Angular Routing

--- a/skills/angular-signals/SKILL.md
+++ b/skills/angular-signals/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: angular-signals
 description: Implement signal-based reactive state management in Angular v20+. Use for creating reactive state with signal(), derived state with computed(), dependent state with linkedSignal(), and side effects with effect(). Triggers on state management questions, converting from BehaviorSubject/Observable patterns to signals, or implementing reactive data flows.
-license: Complete terms in LICENSE.txt
+license: MIT
 metadata:
   category: development
   source:
     repository: https://github.com/analogjs/angular-skills
     path: skills/angular-signals
+    license_path: LICENSE
 ---
 
 # Angular Signals

--- a/skills/angular-ssr/SKILL.md
+++ b/skills/angular-ssr/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: angular-ssr
 description: Implement server-side rendering and hydration in Angular v20+ using @angular/ssr. Use for SSR setup, hydration strategies, prerendering static pages, and handling browser-only APIs. Triggers on SSR configuration, fixing hydration mismatches, prerendering routes, or making code SSR-compatible.
-license: Complete terms in LICENSE.txt
+license: MIT
 metadata:
   category: development
   source:
     repository: https://github.com/analogjs/angular-skills
     path: skills/angular-ssr
+    license_path: LICENSE
 ---
 
 # Angular SSR

--- a/skills/angular-testing/SKILL.md
+++ b/skills/angular-testing/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: angular-testing
 description: Write unit and integration tests for Angular v21+ applications using Vitest or Jasmine with TestBed, component harnesses, and modern testing patterns. Use for testing components with signals, OnPush change detection, services with inject(), and HTTP interactions. Triggers on test creation, testing signal-based components, mocking dependencies, or setting up test infrastructure.
-license: Complete terms in LICENSE.txt
+license: MIT
 metadata:
   category: development
   source:
     repository: https://github.com/analogjs/angular-skills
     path: skills/angular-testing
+    license_path: LICENSE
 ---
 
 # Angular Testing

--- a/skills/angular-tooling/SKILL.md
+++ b/skills/angular-tooling/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: angular-tooling
 description: Use Angular CLI and development tools effectively in Angular v20+ projects. Use for project setup, code generation, building, testing, and configuration. Triggers on creating new projects, generating components/services/modules, configuring builds, running tests, or optimizing production builds.
-license: Complete terms in LICENSE.txt
+license: MIT
 metadata:
   category: development
   source:
     repository: https://github.com/analogjs/angular-skills
     path: skills/angular-tooling
+    license_path: LICENSE
 ---
 
 # Angular Tooling


### PR DESCRIPTION
## Summary

- Add `license_path: LICENSE` to all 10 angular skills, pointing to the repo-root MIT license in `analogjs/angular-skills`
- Correct `license` field from `Complete terms in LICENSE.txt` (which was actually Apache 2.0) to `MIT` matching the actual upstream license
- Update `update-skills.ts` to save and restore local LICENSE files when the upstream doesn't provide one, preventing license loss for skills like the vercel skills where no upstream LICENSE file exists
