### PR TITLE
feat: add grill-me skill

### DIFF
--- a/skills/grill-me/SKILL.md
+++ b/skills/grill-me/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: grill-me
+description: >-
+  Interview the user relentlessly about a plan or design until reaching shared
+  understanding, resolving each branch of the decision tree. Use when user wants
+  to stress-test a plan, get grilled on their design, or mentions "grill me".
+metadata:
+  category: development
+  source:
+    repository: 'https://github.com/mattpocock/skills'
+    path: grill-me
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/skills/marketplace.yaml
+++ b/skills/marketplace.yaml
@@ -267,6 +267,15 @@ items:
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/frontend-design
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/frontend-design/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/frontend-design.tar.gz
+  - id: grill-me
+    description: >-
+      Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch
+      of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill
+      me".
+    category: development
+    githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/grill-me
+    rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/grill-me/SKILL.md
+    content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/grill-me.tar.gz
   - id: langsmith-fetch
     description: >-
       Debug LangChain and LangGraph agents by fetching execution traces from LangSmith Studio. Use when debugging agent


### PR DESCRIPTION
Adds the `grill-me` skill from [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/grill-me).

This skill interviews the user relentlessly about a plan or design until reaching shared understanding.