### PR TITLE
Add Miro MCP server

### DIFF
--- a/mcps/marketplace.yaml
+++ b/mcps/marketplace.yaml
@@ -1656,6 +1656,30 @@ items:
             "type": "streamable-http",
             "url": "https://learn.microsoft.com/api/mcp"
           }
+  - id: miro-mcp
+    name: Miro
+    description: Connects AI assistants to Miro boards via Miro's hosted MCP server, enabling board content creation,
+      reading, diagram generation, summarization, and code generation from Miro board context.
+    author: miro
+    url: https://developers.miro.com/docs/miro-mcp
+    tags:
+      - miro
+      - whiteboard
+      - collaboration
+      - diagram
+      - visual-canvas
+      - board-management
+      - design
+      - planning
+    prerequisites:
+      - Miro account
+    content:
+      - name: Streamable HTTP
+        content: |
+          {
+            "type": "streamable-http",
+            "url": "https://mcp.miro.com/"
+          }
   - id: motherduck
     name: MotherDuck
     description: Enables database operations with MotherDuck and local DuckDB, providing tools for connection

--- a/mcps/miro-mcp/MCP.yaml
+++ b/mcps/miro-mcp/MCP.yaml
@@ -1,0 +1,24 @@
+id: miro-mcp
+name: Miro
+description: Connects AI assistants to Miro boards via Miro's hosted MCP server, enabling board content
+  creation, reading, diagram generation, summarization, and code generation from Miro board context.
+author: miro
+url: https://developers.miro.com/docs/miro-mcp
+tags:
+  - miro
+  - whiteboard
+  - collaboration
+  - diagram
+  - visual-canvas
+  - board-management
+  - design
+  - planning
+prerequisites:
+  - Miro account
+content:
+  - name: Streamable HTTP
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://mcp.miro.com/"
+      }


### PR DESCRIPTION
## Summary
- Adds Miro's hosted MCP server (`https://mcp.miro.com/`) to the marketplace
- Enables AI assistants to interact with Miro boards: create/read content, generate diagrams, summarize boards, and generate code from board context
## Details
- **Transport**: Streamable HTTP (remote, hosted by Miro)
- **Auth**: OAuth 2.0 (browser-based flow, no API keys required)
- **Docs**: https://developers.miro.com/docs/connecting-miro-mcp-to-ai-coding-tools
- **Entry**: `mcps/miro-mcp/MCP.yaml` + regenerated `mcps/marketplace.yaml`
```

## Details
- **Transport**: Streamable HTTP (remote, hosted by Miro)
- **Auth**: OAuth 2.0 (browser-based flow, no API keys required)
- **Docs**: https://developers.miro.com/docs/connecting-miro-mcp-to-ai-coding-tools
- **Entry**: `mcps/miro-mcp/MCP.yaml` + regenerated `mcps/marketplace.yaml`
```
## Verification
- Confirm `mcps/miro-mcp/MCP.yaml` exists with correct YAML structure
- Confirm `mcps/marketplace.yaml` includes the new `miro-mcp` entry (alphabetically sorted)
- Run `npx tsx bin/generate-mcps-marketplace.ts` to verify no parse errors