### PR TITLE
Add Directus MCP server to marketplace

### DIFF
--- a/mcps/directus/MCP.yaml
+++ b/mcps/directus/MCP.yaml
@@ -9,8 +9,10 @@ tags:
   - content-management
   - headless-cms
   - api-integration
+prerequisites:
+  - Directus instance (v11.12+ for built-in MCP)
 content:
-  - name: NPX (Local MCP)
+  - name: NPX (Token Auth)
     prerequisites:
       - Node.js
     content: |
@@ -22,7 +24,7 @@ content:
           "DIRECTUS_TOKEN": "{{DIRECTUS_TOKEN}}"
         }
       }
-  - name: NPX (Local MCP with Email/Password)
+  - name: NPX (Email/Password Auth)
     prerequisites:
       - Node.js
     content: |
@@ -35,7 +37,7 @@ content:
           "DIRECTUS_USER_PASSWORD": "{{DIRECTUS_USER_PASSWORD}}"
         }
       }
-  - name: Streamable HTTP (Built-in MCP)
+  - name: Streamable HTTP
     prerequisites:
       - Directus v11.12+
     content: |

--- a/mcps/directus/MCP.yaml
+++ b/mcps/directus/MCP.yaml
@@ -1,7 +1,7 @@
 id: directus
 name: Directus
-description: Directus Content MCP Server that provides seamless integration with Directus APIs, enabling AI tools to manage content, collections, fields, and automation workflows.
-author: directus
+description: Directus Content MCP Server that provides seamless integration with Directus APIs, enabling AI tools to manage content, collections, fields, automation workflows, and more.
+author: Abhinay Me
 url: https://github.com/directus/mcp
 tags:
   - directus
@@ -9,19 +9,43 @@ tags:
   - content-management
   - headless-cms
   - api-integration
-prerequisites:
-  - Node.js
-  - Directus v11.12+ (for built-in MCP) or any version with @directus/content-mcp
-  - Directus URL and authentication token or user credentials
-content: |
-  {
-    "command": "npx",
-    "args": ["@directus/content-mcp@latest"],
-    "env": {
-      "DIRECTUS_URL": "{{DIRECTUS_URL}}",
-      "DIRECTUS_TOKEN": "{{DIRECTUS_TOKEN}}"
-    }
-  }
+content:
+  - name: NPX (Local MCP)
+    prerequisites:
+      - Node.js
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "@directus/content-mcp@latest"],
+        "env": {
+          "DIRECTUS_URL": "{{DIRECTUS_URL}}",
+          "DIRECTUS_TOKEN": "{{DIRECTUS_TOKEN}}"
+        }
+      }
+  - name: NPX (Local MCP with Email/Password)
+    prerequisites:
+      - Node.js
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "@directus/content-mcp@latest"],
+        "env": {
+          "DIRECTUS_URL": "{{DIRECTUS_URL}}",
+          "DIRECTUS_USER_EMAIL": "{{DIRECTUS_USER_EMAIL}}",
+          "DIRECTUS_USER_PASSWORD": "{{DIRECTUS_USER_PASSWORD}}"
+        }
+      }
+  - name: Streamable HTTP (Built-in MCP)
+    prerequisites:
+      - Directus v11.12+
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "{{DIRECTUS_URL}}/mcp",
+        "headers": {
+          "Authorization": "Bearer {{DIRECTUS_TOKEN}}"
+        }
+      }
 parameters:
   - name: Directus URL
     key: DIRECTUS_URL

--- a/mcps/directus/MCP.yaml
+++ b/mcps/directus/MCP.yaml
@@ -1,7 +1,7 @@
 id: directus
 name: Directus
 description: Directus Content MCP Server that provides seamless integration with Directus APIs, enabling AI tools to manage content, collections, fields, automation workflows, and more.
-author: Abhinay Me
+author: directus
 url: https://github.com/directus/mcp
 tags:
   - directus
@@ -9,6 +9,7 @@ tags:
   - content-management
   - headless-cms
   - api-integration
+  - official
 prerequisites:
   - Directus instance (v11.12+ for built-in MCP)
 content:

--- a/mcps/directus/MCP.yaml
+++ b/mcps/directus/MCP.yaml
@@ -1,0 +1,39 @@
+id: directus
+name: Directus
+description: Directus Content MCP Server that provides seamless integration with Directus APIs, enabling AI tools to manage content, collections, fields, and automation workflows.
+author: directus
+url: https://github.com/directus/mcp
+tags:
+  - directus
+  - cms
+  - content-management
+  - headless-cms
+  - api-integration
+prerequisites:
+  - Node.js
+  - Directus v11.12+ (for built-in MCP) or any version with @directus/content-mcp
+  - Directus URL and authentication token or user credentials
+content: |
+  {
+    "command": "npx",
+    "args": ["@directus/content-mcp@latest"],
+    "env": {
+      "DIRECTUS_URL": "{{DIRECTUS_URL}}",
+      "DIRECTUS_TOKEN": "{{DIRECTUS_TOKEN}}"
+    }
+  }
+parameters:
+  - name: Directus URL
+    key: DIRECTUS_URL
+    placeholder: https://your-directus-instance.com
+  - name: Directus Token
+    key: DIRECTUS_TOKEN
+    placeholder: your_directus_token_here
+  - name: Directus User Email
+    key: DIRECTUS_USER_EMAIL
+    placeholder: user@example.com
+    optional: true
+  - name: Directus User Password
+    key: DIRECTUS_USER_PASSWORD
+    placeholder: your_password_here
+    optional: true

--- a/mcps/directus/MCP.yaml
+++ b/mcps/directus/MCP.yaml
@@ -19,7 +19,7 @@ content: |
     "args": ["-y", "@directus/content-mcp@latest"],
     "env": {
       "DIRECTUS_URL": "{{DIRECTUS_URL}}",
-      "DIRECTUS_TOKEN": "{{DIRECTUS_TOKEN}}"
+      "DIRECTUS_TOKEN": "{{DIRECTUS_TOKEN}}",
     }
   }
 parameters:

--- a/mcps/directus/MCP.yaml
+++ b/mcps/directus/MCP.yaml
@@ -16,7 +16,7 @@ prerequisites:
 content: |
   {
     "command": "npx",
-    "args": ["@directus/content-mcp@latest"],
+    "args": ["-y", "@directus/content-mcp@latest"],
     "env": {
       "DIRECTUS_URL": "{{DIRECTUS_URL}}",
       "DIRECTUS_TOKEN": "{{DIRECTUS_TOKEN}}"


### PR DESCRIPTION
This pull request adds a new MCP configuration for Directus, enabling seamless integration with Directus APIs for content management and automation. The configuration provides multiple authentication options and outlines required parameters for setup.

Directus MCP integration:

* Added `mcps/directus/MCP.yaml` to define the Directus Content MCP Server, including metadata such as name, description, author, and tags.
* Provided three connection methods: NPX with token authentication, NPX with email/password authentication, and a streamable HTTP connection for Directus v11.12+, each with their respective prerequisites and environment variables.
* Specified required parameters (`DIRECTUS_URL`, `DIRECTUS_TOKEN`, `DIRECTUS_USER_EMAIL`, `DIRECTUS_USER_PASSWORD`) with placeholders and optional flags for user credentials.