### PR TITLE
docs: add SignalSpore MCP server

### DIFF
--- a/mcps/marketplace.yaml
+++ b/mcps/marketplace.yaml
@@ -2590,6 +2590,54 @@ items:
             "command": "docker",
             "args": ["run", "--rm", "-i", "mcp/sequentialthinking"]
           }
+  - id: signalspore
+    name: SignalSpore
+    description: >
+      Model-aware preflight MCP server for AI coding agents. SignalSpore lets an agent run a local gate, request a
+      task-start preflight card before risky shell, migration, deploy, database, or integration work, and submit one
+      sanitized post-task delta so future runs get sharper.
+    author: yeahdog
+    url: https://github.com/yeahdog/signalspore-mcp
+    tags:
+      - ai-agent
+      - agent-safety
+      - preflight
+      - coding-agents
+      - model-context-protocol
+      - mcp
+      - risk-management
+    prerequisites:
+      - Node.js
+      - SignalSpore setup policy and write token from https://www.signalspore.com/setup
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "@yeahdog/signalspore-mcp@0.1.5"],
+        "env": {
+          "SIGNALSPORE_BASE_URL": "https://www.signalspore.com",
+          "SIGNALSPORE_AGENT_POLICY_ID": "{{SIGNALSPORE_AGENT_POLICY_ID}}",
+          "SIGNALSPORE_WRITE_TOKEN": "{{SIGNALSPORE_WRITE_TOKEN}}",
+          "SIGNALSPORE_MODEL_PROVIDER": "{{SIGNALSPORE_MODEL_PROVIDER}}",
+          "SIGNALSPORE_MODEL_NAME": "{{SIGNALSPORE_MODEL_NAME}}",
+          "SIGNALSPORE_MODEL_TIER": "{{SIGNALSPORE_MODEL_TIER}}"
+        }
+      }
+    parameters:
+      - name: SignalSpore Agent Policy ID
+        key: SIGNALSPORE_AGENT_POLICY_ID
+        placeholder: policy_from_signalspore_setup
+      - name: SignalSpore Write Token
+        key: SIGNALSPORE_WRITE_TOKEN
+        placeholder: token_from_signalspore_setup
+      - name: Model Provider
+        key: SIGNALSPORE_MODEL_PROVIDER
+        placeholder: operator-runtime
+      - name: Model Name
+        key: SIGNALSPORE_MODEL_NAME
+        placeholder: external-agent
+      - name: Model Tier
+        key: SIGNALSPORE_MODEL_TIER
+        placeholder: frontier_reasoning
   - id: slack
     name: Slack
     description: Enables AI assistants to interact with Slack workspaces, providing tools for messaging, channel management,

--- a/mcps/signalspore/MCP.yaml
+++ b/mcps/signalspore/MCP.yaml
@@ -17,7 +17,7 @@ tags:
 prerequisites:
   - Node.js
   - SignalSpore setup policy and write token from https://www.signalspore.com/setup
-content: >
+content: |
   {
     "command": "npx",
     "args": ["-y", "@yeahdog/signalspore-mcp@0.1.5"],

--- a/mcps/signalspore/MCP.yaml
+++ b/mcps/signalspore/MCP.yaml
@@ -1,0 +1,48 @@
+id: signalspore
+name: SignalSpore
+description: >
+  Model-aware preflight MCP server for AI coding agents. SignalSpore lets an agent run a local gate,
+  request a task-start preflight card before risky shell, migration, deploy, database, or integration work,
+  and submit one sanitized post-task delta so future runs get sharper.
+author: yeahdog
+url: https://github.com/yeahdog/signalspore-mcp
+tags:
+  - ai-agent
+  - agent-safety
+  - preflight
+  - coding-agents
+  - model-context-protocol
+  - mcp
+  - risk-management
+prerequisites:
+  - Node.js
+  - SignalSpore setup policy and write token from https://www.signalspore.com/setup
+content: >
+  {
+    "command": "npx",
+    "args": ["-y", "@yeahdog/signalspore-mcp@0.1.5"],
+    "env": {
+      "SIGNALSPORE_BASE_URL": "https://www.signalspore.com",
+      "SIGNALSPORE_AGENT_POLICY_ID": "{{SIGNALSPORE_AGENT_POLICY_ID}}",
+      "SIGNALSPORE_WRITE_TOKEN": "{{SIGNALSPORE_WRITE_TOKEN}}",
+      "SIGNALSPORE_MODEL_PROVIDER": "{{SIGNALSPORE_MODEL_PROVIDER}}",
+      "SIGNALSPORE_MODEL_NAME": "{{SIGNALSPORE_MODEL_NAME}}",
+      "SIGNALSPORE_MODEL_TIER": "{{SIGNALSPORE_MODEL_TIER}}"
+    }
+  }
+parameters:
+  - name: SignalSpore Agent Policy ID
+    key: SIGNALSPORE_AGENT_POLICY_ID
+    placeholder: policy_from_signalspore_setup
+  - name: SignalSpore Write Token
+    key: SIGNALSPORE_WRITE_TOKEN
+    placeholder: token_from_signalspore_setup
+  - name: Model Provider
+    key: SIGNALSPORE_MODEL_PROVIDER
+    placeholder: operator-runtime
+  - name: Model Name
+    key: SIGNALSPORE_MODEL_NAME
+    placeholder: external-agent
+  - name: Model Tier
+    key: SIGNALSPORE_MODEL_TIER
+    placeholder: frontier_reasoning


### PR DESCRIPTION
Adds SignalSpore's published MCP server to the Kilo Marketplace MCP catalog.

Why this fits Kilo agents:
- SignalSpore is a task-start preflight server for AI coding agents before risky shell, migration, deploy, database, or brittle-integration work.
- The package is live on npm: `@yeahdog/signalspore-mcp@0.1.5`.
- The MCP server exposes setup, local gate, preflight, and sanitized delta tools.

Verification performed:

```sh
npm view @yeahdog/signalspore-mcp version
# 0.1.5

cd /tmp
npx -y @yeahdog/signalspore-mcp@0.1.5 --version
# 0.1.5

npx tsx bin/generate-mcps-marketplace.ts
# Generated marketplace.yaml with 64 MCPs
```

Docs/proof:
- Repo: https://github.com/yeahdog/signalspore-mcp
- Release: https://github.com/yeahdog/signalspore-mcp/releases/tag/v0.1.5
- Setup: https://www.signalspore.com/setup
- MCP docs: https://www.signalspore.com/mcp
- External smoke path: https://www.signalspore.com/external-smoke
