### PR TITLE
Allow architect plans in .plans

### DIFF
--- a/agents/architect/AGENT_DEFINITION.md
+++ b/agents/architect/AGENT_DEFINITION.md
@@ -13,6 +13,7 @@ permission:
   edit:
     "*": deny
     .kilo/plans/*.md: allow
+    .plans/*.md: allow
     .opencode/plans/*.md: allow
   bash: deny
   mcp: deny
@@ -41,10 +42,11 @@ Planning behavior:
 Plan files:
 
 - You may create and edit plan Markdown files only.
-- Save plans to the exact plan path provided by the latest system reminder / Plan File section.
-- Never invent a plan filename from the feature name or title.
+- Follow the latest system reminder / Plan File section for the target plan location.
+- Prefer `.kilo/plans/` with a concise kebab-case filename based on the plan details when no exact plan path is provided.
+- Use `.plans/` or `.opencode/plans/` only when requested or required by the repo/client and your permissions allow it.
 - Do not write the final plan or call `plan_exit` until the user chooses "Finalize and save the plan".
-- After final approval, write the final plan to the exact plan path, then call `plan_exit` with no arguments.
+- After final approval, write the final plan to the chosen plan file, then call `plan_exit`. If `plan_exit` supports a path argument or the system reminder asks for one, pass the saved plan path.
 - Do not edit source files or non-plan documentation files.
 - Do not run mutating commands.
 - If implementation requires source edits or mutating commands, tell the user to switch to an implementation-capable agent.
@@ -57,7 +59,7 @@ Completion behavior:
   1. Finalize and save the plan
   2. Continue refining
 - Recommend "Finalize and save the plan" only when the goal, constraints, affected boundaries, data flow, failure modes, rollout or migration path, and validation plan are addressed or explicitly out of scope.
-- If the user chooses "Finalize and save the plan", write the complete finalized Markdown plan to the exact plan path, then call `plan_exit` with no arguments.
+- If the user chooses "Finalize and save the plan", write the complete finalized Markdown plan to the chosen plan file, then call `plan_exit` as described above.
 - If the user chooses "Continue refining", keep planning and do not write the final plan or call `plan_exit`.
 - After `plan_exit`, rely on the client follow-up to ask whether the user wants to implement the saved plan in a new session.
 - Do not implement source or documentation changes as this agent.

--- a/agents/marketplace.yaml
+++ b/agents/marketplace.yaml
@@ -47,13 +47,18 @@ items:
 
         - You may create and edit plan Markdown files only.
 
-        - Save plans to the exact plan path provided by the latest system reminder / Plan File section.
+        - Follow the latest system reminder / Plan File section for the target plan location.
 
-        - Never invent a plan filename from the feature name or title.
+        - Prefer `.kilo/plans/` with a concise kebab-case filename based on the plan details when no exact plan path is
+        provided.
+
+        - Use `.plans/` or `.opencode/plans/` only when requested or required by the repo/client and your permissions
+        allow it.
 
         - Do not write the final plan or call `plan_exit` until the user chooses "Finalize and save the plan".
 
-        - After final approval, write the final plan to the exact plan path, then call `plan_exit` with no arguments.
+        - After final approval, write the final plan to the chosen plan file, then call `plan_exit`. If `plan_exit`
+        supports a path argument or the system reminder asks for one, pass the saved plan path.
 
         - Do not edit source files or non-plan documentation files.
 
@@ -78,8 +83,8 @@ items:
         - Recommend "Finalize and save the plan" only when the goal, constraints, affected boundaries, data flow,
         failure modes, rollout or migration path, and validation plan are addressed or explicitly out of scope.
 
-        - If the user chooses "Finalize and save the plan", write the complete finalized Markdown plan to the exact plan
-        path, then call `plan_exit` with no arguments.
+        - If the user chooses "Finalize and save the plan", write the complete finalized Markdown plan to the chosen
+        plan file, then call `plan_exit` as described above.
 
         - If the user chooses "Continue refining", keep planning and do not write the final plan or call `plan_exit`.
 
@@ -94,11 +99,13 @@ items:
         agent needs to execute safely.
       options:
         displayName: Architect
+        id: architect
       permission:
         read: allow
         edit:
           "*": deny
           .kilo/plans/*.md: allow
+          .plans/*.md: allow
           .opencode/plans/*.md: allow
         bash: deny
         mcp: deny
@@ -125,6 +132,7 @@ items:
         Be specific and actionable in suggestions.
       options:
         displayName: Code Reviewer
+        id: code-reviewer
       permission:
         read: allow
         bash: allow
@@ -216,6 +224,7 @@ items:
         and modify. Every refactoring should make the codebase demonstrably better.
       options:
         displayName: Code Simplifier
+        id: code-simplifier
       permission:
         read: allow
         edit: allow
@@ -299,6 +308,7 @@ items:
         Your motto: "Show me the logs or it didn't happen."
       options:
         displayName: Code Skeptic
+        id: code-skeptic
       permission:
         read: allow
         edit:
@@ -329,6 +339,7 @@ items:
         consistency in tone and style.
       options:
         displayName: Documentation Specialist
+        id: docs-specialist
       permission:
         read: allow
         edit:
@@ -364,6 +375,7 @@ items:
         Prioritize accessibility, responsive design, and performance. Use semantic HTML and follow React best practices.
       options:
         displayName: Frontend Specialist
+        id: frontend-specialist
       permission:
         read: allow
         edit:
@@ -400,6 +412,7 @@ items:
         path and error scenarios.
       options:
         displayName: Test Engineer
+        id: test-engineer
       permission:
         read: allow
         edit:

--- a/bin/generate-agents-marketplace.ts
+++ b/bin/generate-agents-marketplace.ts
@@ -85,6 +85,7 @@ function agentFromMarkdown(dirName: string): MarketplaceAgent {
     options: {
       displayName: name,
       ...(options as Record<string, unknown>),
+      id,
     },
   };
 

--- a/modes/architect/MODE.yaml
+++ b/modes/architect/MODE.yaml
@@ -21,7 +21,7 @@ content: |
   groups:
     - read
     - - edit
-      - fileRegex: (^|/)(\.kilo|\.opencode)/plans/.*\.md$
+      - fileRegex: (^|/)((\.kilo|\.opencode)/plans|\.plans)/.*\.md$
         description: Plan markdown files only
 
   customInstructions: |
@@ -41,7 +41,7 @@ content: |
     Plan files:
 
     - You may create and edit plan Markdown files only.
-    - Save plans under `.kilo/plans/` unless the user asks for another allowed plan-file location.
+    - Save plans under `.kilo/plans/` by default, or under `.plans/` / `.opencode/plans/` when requested or required by the repo/client.
     - Do not edit source files or non-plan documentation files.
     - Do not run mutating commands.
     - If implementation requires source edits or mutating commands, tell the user to switch to an implementation-capable mode.

--- a/modes/marketplace.yaml
+++ b/modes/marketplace.yaml
@@ -25,7 +25,7 @@ items:
       groups:
         - read
         - - edit
-          - fileRegex: (^|/)(\.kilo|\.opencode)/plans/.*\.md$
+          - fileRegex: (^|/)((\.kilo|\.opencode)/plans|\.plans)/.*\.md$
             description: Plan markdown files only
 
       customInstructions: |
@@ -45,7 +45,7 @@ items:
         Plan files:
 
         - You may create and edit plan Markdown files only.
-        - Save plans under `.kilo/plans/` unless the user asks for another allowed plan-file location.
+        - Save plans under `.kilo/plans/` by default, or under `.plans/` / `.opencode/plans/` when requested or required by the repo/client.
         - Do not edit source files or non-plan documentation files.
         - Do not run mutating commands.
         - If implementation requires source edits or mutating commands, tell the user to switch to an implementation-capable mode.


### PR DESCRIPTION
## Summary
- Allow architect agents/modes to write plan markdown files under `.plans/` in addition to `.kilo/plans/` and `.opencode/plans/`.
- Update architect instructions to choose an allowed plan path when no exact path is provided.
- Include generated marketplace agent IDs for published agent metadata.

## Testing
- Built marketplace definition locally