### PR TITLE
feat(mcps): add Mailtrap MCP server

### DIFF
--- a/mcps/mailtrap/MCP.yaml
+++ b/mcps/mailtrap/MCP.yaml
@@ -1,0 +1,45 @@
+id: mailtrap
+name: Mailtrap
+description: Send transactional emails, test safely in sandbox, manage templates, and inspect delivery logs via Mailtrap
+  Email API. Sandbox testing works out of the box; production sends require a verified sending domain.
+author: mailtrap
+url: https://github.com/mailtrap/mailtrap-mcp
+tags:
+  - email
+  - mailtrap
+  - transactional-email
+  - testing
+  - notifications
+prerequisites:
+  - Mailtrap account
+  - Node.js
+content:
+  - name: NPX
+    prerequisites:
+      - Node.js
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "mcp-mailtrap"],
+        "env": {
+          "MAILTRAP_API_TOKEN": "{{MAILTRAP_API_TOKEN}}",
+          "MAILTRAP_ACCOUNT_ID": "{{MAILTRAP_ACCOUNT_ID}}",
+          "DEFAULT_FROM_EMAIL": "{{DEFAULT_FROM_EMAIL}}",
+          "MAILTRAP_TEST_INBOX_ID": "{{MAILTRAP_TEST_INBOX_ID}}"
+        }
+      }
+parameters:
+  - name: Mailtrap API Token
+    key: MAILTRAP_API_TOKEN
+    placeholder: your_mailtrap_api_token
+  - name: Mailtrap Account ID
+    key: MAILTRAP_ACCOUNT_ID
+    placeholder: your_account_id
+  - name: Default From Email
+    key: DEFAULT_FROM_EMAIL
+    placeholder: sender@yourdomain.com
+    optional: true
+  - name: Test Inbox ID
+    key: MAILTRAP_TEST_INBOX_ID
+    placeholder: your_sandbox_inbox_id
+    optional: true

--- a/mcps/marketplace.yaml
+++ b/mcps/marketplace.yaml
@@ -1549,6 +1549,51 @@ items:
         key: LINEAR_PATH
         placeholder: /path/to/linear-mcp
         optional: true
+  - id: mailtrap
+    name: Mailtrap
+    description: Send transactional emails, test safely in sandbox, manage templates, and inspect delivery logs via Mailtrap
+      Email API. Sandbox testing works out of the box; production sends require a verified sending domain.
+    author: mailtrap
+    url: https://github.com/mailtrap/mailtrap-mcp
+    tags:
+      - email
+      - mailtrap
+      - transactional-email
+      - testing
+      - notifications
+    prerequisites:
+      - Mailtrap account
+      - Node.js
+    content:
+      - name: NPX
+        prerequisites:
+          - Node.js
+        content: |
+          {
+            "command": "npx",
+            "args": ["-y", "mcp-mailtrap"],
+            "env": {
+              "MAILTRAP_API_TOKEN": "{{MAILTRAP_API_TOKEN}}",
+              "MAILTRAP_ACCOUNT_ID": "{{MAILTRAP_ACCOUNT_ID}}",
+              "DEFAULT_FROM_EMAIL": "{{DEFAULT_FROM_EMAIL}}",
+              "MAILTRAP_TEST_INBOX_ID": "{{MAILTRAP_TEST_INBOX_ID}}"
+            }
+          }
+    parameters:
+      - name: Mailtrap API Token
+        key: MAILTRAP_API_TOKEN
+        placeholder: your_mailtrap_api_token
+      - name: Mailtrap Account ID
+        key: MAILTRAP_ACCOUNT_ID
+        placeholder: your_account_id
+      - name: Default From Email
+        key: DEFAULT_FROM_EMAIL
+        placeholder: sender@yourdomain.com
+        optional: true
+      - name: Test Inbox ID
+        key: MAILTRAP_TEST_INBOX_ID
+        placeholder: your_sandbox_inbox_id
+        optional: true
   - id: memory
     name: Knowledge Graph Memory
     description: A persistent memory system using a local knowledge graph that enables AI assistants to remember information


### PR DESCRIPTION
## Summary
- Adds official Mailtrap MCP (`mcp-mailtrap`) to the marketplace catalog
- First transactional email / sandbox-testing MCP in this repo
- Contributed on behalf of Mailtrap (official first-party MCP server)

## Test plan
- [x] Installed via NPX config in Cursor (existing `mcp-mailtrap` setup)
- [x] Verified `list-templates` returns templates
- [x] Verified `get-sandbox-messages` returns sandbox inbox messages
- [x] Regenerated `mcps/marketplace.yaml`

## Links
- MCP repo: https://github.com/mailtrap/mailtrap-mcp
- npm: https://www.npmjs.com/package/mcp-mailtrap
- Docs: https://docs.mailtrap.io/guides/ai-powered-integrations/mcp-server

Made with [Cursor](https://cursor.com)