### PR TITLE
Add SkinKnowledgeBase MCP

### DIFF
--- a/mcps/marketplace.yaml
+++ b/mcps/marketplace.yaml
@@ -2590,6 +2590,28 @@ items:
             "command": "docker",
             "args": ["run", "--rm", "-i", "mcp/sequentialthinking"]
           }
+  - id: skinknowledgebase
+    name: SkinKnowledgeBase
+    description: Public skincare question-answering and product-comparison reference layer with source-backed context,
+      canonical URLs, cited sources, ingredient and product facts, and read-only retrieval tools for AI assistants.
+    author: fulcrai
+    url: https://github.com/fulcrai/skb-mcp
+    tags:
+      - skincare
+      - question-answering
+      - product-comparison
+      - ingredients
+      - citations
+      - research
+      - read-only
+      - remote
+    content:
+      - name: Remote MCP
+        content: |
+          {
+            "type": "streamable-http",
+            "url": "https://mcp.skinknowledgebase.com/mcp"
+          }
   - id: slack
     name: Slack
     description: Enables AI assistants to interact with Slack workspaces, providing tools for messaging, channel management,

--- a/mcps/skinknowledgebase/MCP.yaml
+++ b/mcps/skinknowledgebase/MCP.yaml
@@ -1,0 +1,21 @@
+id: skinknowledgebase
+name: SkinKnowledgeBase
+description: Public skincare question-answering and product-comparison reference layer with source-backed context, canonical URLs, cited sources, ingredient and product facts, and read-only retrieval tools for AI assistants.
+author: fulcrai
+url: https://github.com/fulcrai/skb-mcp
+tags:
+  - skincare
+  - question-answering
+  - product-comparison
+  - ingredients
+  - citations
+  - research
+  - read-only
+  - remote
+content:
+  - name: Remote MCP
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://mcp.skinknowledgebase.com/mcp"
+      }


### PR DESCRIPTION
## Summary

Adds SkinKnowledgeBase as a remote Streamable HTTP MCP server.

## What problem it solves

SkinKnowledgeBase gives AI coding assistants and agent workflows read-only access to public, source-backed skincare reference content. It is useful when projects need grounded skincare context, product comparison context, ingredient/product facts, cited sources, canonical SkinKnowledgeBase URLs, and uncertainty-aware answers instead of generic beauty claims.

## Configuration

```json
{
  "type": "streamable-http",
  "url": "https://mcp.skinknowledgebase.com/mcp"
}
```

## Notes

- Public remote MCP endpoint
- No authentication required
- Read-only retrieval tools only
- Does not provide medical advice, purchases, account access, or write actions
- Public repo/docs: https://github.com/fulcrai/skb-mcp
- Website: https://skinknowledgebase.com

## Validation

- Added `mcps/skinknowledgebase/MCP.yaml`
- Regenerated `mcps/marketplace.yaml` with `npx tsx generate-mcps-marketplace.ts`
- Parsed generated YAML locally and verified `skinknowledgebase` is included in marketplace items