### PR TITLE
Add mobile-mcp MCP server for mobile automation (iOS/Android)

### DIFF
--- a/mcps/marketplace.yaml
+++ b/mcps/marketplace.yaml
@@ -1683,7 +1683,7 @@ items:
         content: |
           {
             "command": "npx",
-            "args": ["-y", "@mobilenext/mobile-mcp@latest"]
+            "args": ["-y", "@mobilenext/mobile-mcp@0.0.57"]
           }
     parameters:
       - name: Disable Telemetry

--- a/mcps/marketplace.yaml
+++ b/mcps/marketplace.yaml
@@ -1656,6 +1656,40 @@ items:
             "type": "streamable-http",
             "url": "https://learn.microsoft.com/api/mcp"
           }
+  - id: mobile-mcp
+    name: Mobile MCP
+    description: Enables AI assistants to automate and interact with mobile devices including iOS simulators, Android
+      emulators, and real devices. Supports app management, screen interaction, UI element inspection, and device
+      control through a unified API.
+    author: mobile-next
+    url: https://github.com/mobile-next/mobile-mcp
+    tags:
+      - mobile
+      - ios
+      - android
+      - automation
+      - testing
+      - simulator
+      - emulator
+      - mcp
+    prerequisites:
+      - Node.js v22+
+      - Xcode command line tools (for iOS)
+      - Android Platform Tools (for Android)
+    content:
+      - name: NPX
+        prerequisites:
+          - Node.js v22+
+        content: |
+          {
+            "command": "npx",
+            "args": ["-y", "@mobilenext/mobile-mcp@latest"]
+          }
+    parameters:
+      - name: Disable Telemetry
+        key: MOBILEMCP_DISABLE_TELEMETRY
+        placeholder: "1"
+        optional: true
   - id: motherduck
     name: MotherDuck
     description: Enables database operations with MotherDuck and local DuckDB, providing tools for connection

--- a/mcps/mobile-mcp/MCP.yaml
+++ b/mcps/mobile-mcp/MCP.yaml
@@ -1,0 +1,32 @@
+id: mobile-mcp
+name: Mobile MCP
+description: Enables AI assistants to automate and interact with mobile devices including iOS simulators, Android emulators, and real devices. Supports app management, screen interaction, UI element inspection, and device control through a unified API.
+author: mobile-next
+url: https://github.com/mobile-next/mobile-mcp
+tags:
+  - mobile
+  - ios
+  - android
+  - automation
+  - testing
+  - simulator
+  - emulator
+  - mcp
+prerequisites:
+  - Node.js v22+
+  - Xcode command line tools (for iOS)
+  - Android Platform Tools (for Android)
+content:
+  - name: NPX
+    prerequisites:
+      - Node.js v22+
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "@mobilenext/mobile-mcp@latest"]
+      }
+parameters:
+  - name: Disable Telemetry
+    key: MOBILEMCP_DISABLE_TELEMETRY
+    placeholder: "1"
+    optional: true

--- a/mcps/mobile-mcp/MCP.yaml
+++ b/mcps/mobile-mcp/MCP.yaml
@@ -1,4 +1,4 @@
-id: mobile-mcp
+﻿id: mobile-mcp
 name: Mobile MCP
 description: Enables AI assistants to automate and interact with mobile devices including iOS simulators, Android emulators, and real devices. Supports app management, screen interaction, UI element inspection, and device control through a unified API.
 author: mobile-next
@@ -23,7 +23,7 @@ content:
     content: |
       {
         "command": "npx",
-        "args": ["-y", "@mobilenext/mobile-mcp@latest"]
+        "args": ["-y", "@mobilenext/mobile-mcp@0.0.57"]
       }
 parameters:
   - name: Disable Telemetry

--- a/mcps/mobile-mcp/MCP.yaml
+++ b/mcps/mobile-mcp/MCP.yaml
@@ -1,4 +1,4 @@
-﻿id: mobile-mcp
+id: mobile-mcp
 name: Mobile MCP
 description: Enables AI assistants to automate and interact with mobile devices including iOS simulators, Android emulators, and real devices. Supports app management, screen interaction, UI element inspection, and device control through a unified API.
 author: mobile-next


### PR DESCRIPTION
## Summary
- Adds Mobile MCP by mobile-next for iOS/Android device automation
- NPX installation via @mobilenext/mobile-mcp@latest
- Covers simulators, emulators, and real devices
