### PR TITLE
Add Three-Pillar Personal Finance skill

### DIFF
--- a/skills/three-pillar-finance/SKILL.md
+++ b/skills/three-pillar-finance/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: three-pillar-finance
+description: >-
+  Use when a conversation involves personal money — budgeting, saving,
+  investing, allocation, emergency fund, "where should I put my money",
+  financial planning, debt, or money management. Applies the Three-Pillar System
+  (Income − Expenses = Freedom Fund, allocated across Cashflow / Investment /
+  Savings, governed by discipline over strategy) as the reasoning lens for any
+  personal-finance question.
+license: MIT
+metadata:
+  category: finance
+  source:
+    repository: 'https://github.com/nontravis/personal-finance-whitepaper'
+    path: skills/three-pillar-finance
+    license_path: LICENSE
+---
+
+# Three-Pillar Personal Finance — Reasoning Lens
+
+## What this is
+
+A reasoning lens, not a calculator or document generator. When personal-finance topics
+come up, reason and advise through the **Three-Pillar System** instead of giving generic
+money tips. The framework comes from the whitepaper "Foundations of a Personal Finance
+System: The Three Pillars" by Nonthawit Doungsodsri (nonthawit.com), released under the MIT License.
+
+Its core claim: long-term financial success comes not from sophisticated strategy but from
+**discipline** — following a simple system consistently for five to ten years or more.
+
+## The behavioral contract
+
+When a personal-finance topic surfaces, do all four:
+
+1. **Anchor on the equation.** Frame the discussion around `Income − Expenses = Freedom Fund`.
+   If the person has not named that number, surface it first — no plan stands without it.
+
+2. **Route through the three pillars.** Every money question maps to one or more pillar:
+   - **Cashflow** — foundation: know what flows in and out. See `references/pillar-1-cashflow.md`.
+   - **Investment** — offense: put money to work, compounding. See `references/pillar-2-investment.md`.
+   - **Savings (value preservation)** — defense: protect against inflation. See `references/pillar-3-savings.md`.
+
+3. **Apply the decision rules.** The heuristics in `references/decision-rules.md` are the spine.
+   The non-negotiable ones: Cashflow first; Investment AND Savings are both mandatory; invest
+   only in what you understand; ratios are illustrative, never prescribed; discipline over strategy.
+
+4. **Stay humble.** End substantive guidance with one line: *this is an educational framework,
+   not personalized financial advice; it names no specific securities; adapt it to your own
+   situation, local context, and era.*
+
+## Watch for anti-patterns
+
+Before finalizing advice, check it against `references/pitfalls.md` — skipping Savings,
+chasing hype, copying someone else's ratio, stop-start investing, hoarding idle cash,
+over-engineering with complex strategy.
+
+## Reference map
+
+- `references/framework.md` — the equation, allocation example, the discipline principle
+- `references/pillar-1-cashflow.md` · `pillar-2-investment.md` · `pillar-3-savings.md`
+- `references/decision-rules.md` — if/then heuristics
+- `references/pitfalls.md` — anti-patterns

--- a/skills/three-pillar-finance/SKILL.md
+++ b/skills/three-pillar-finance/SKILL.md
@@ -7,7 +7,6 @@ description: >-
   (Income − Expenses = Freedom Fund, allocated across Cashflow / Investment /
   Savings, governed by discipline over strategy) as the reasoning lens for any
   personal-finance question.
-license: MIT
 metadata:
   category: finance
   source:
@@ -57,6 +56,6 @@ over-engineering with complex strategy.
 ## Reference map
 
 - `references/framework.md` — the equation, allocation example, the discipline principle
-- `references/pillar-1-cashflow.md` · `pillar-2-investment.md` · `pillar-3-savings.md`
+- `references/pillar-1-cashflow.md` · `references/pillar-2-investment.md` · `references/pillar-3-savings.md`
 - `references/decision-rules.md` — if/then heuristics
 - `references/pitfalls.md` — anti-patterns

--- a/skills/three-pillar-finance/references/decision-rules.md
+++ b/skills/three-pillar-finance/references/decision-rules.md
@@ -1,0 +1,28 @@
+# Decision rules — the lens's spine
+
+Apply these as explicit if/then checks on any personal-finance guidance.
+
+1. **IF** the Freedom Fund number is unknown → compute `Income − Expenses` first. Do not allocate
+   or recommend investments until it is known.
+
+2. **IF** the Freedom Fund is negative → the first and only goal is to turn it positive (raise
+   income or cut expenses). No investing or saving plan yet.
+
+3. **IF** a plan omits Investment OR omits Savings → it is incomplete. Both are mandatory
+   destinations. Add the missing pillar.
+
+4. **IF** asked "what ratio should I use" → give an illustrative example (e.g. 30/40/30), then
+   stress it is not a formula. Guide the person to design their own from their real situation.
+
+5. **IF** the person wants to invest in something they do not understand → push study-first.
+   Do not endorse it on hype.
+
+6. **IF** asked which specific asset to buy → describe the qualities to look for (for investment:
+   understanding and fit; for savings: inflation resistance, liquidity, acceptance). Do not name a
+   specific security.
+
+7. **IF** the person wants quick wins or market timing → redirect to discipline: DCA, steady
+   saving, a 5–10 year horizon.
+
+8. **ALWAYS** when giving substantive guidance, append the one-line disclaimer: educational
+   framework, not personalized advice, no specific securities, adapt to your context and era.

--- a/skills/three-pillar-finance/references/framework.md
+++ b/skills/three-pillar-finance/references/framework.md
@@ -1,0 +1,34 @@
+# Framework — the connective tissue
+
+## The founding equation
+
+    Income − Expenses = Freedom Fund
+
+The Freedom Fund is the raw material of financial freedom. If it is negative, the first goal
+is to turn it positive. If it is positive, the question becomes how to allocate it. The answer:
+channel it into three pillars that work together — Cashflow, Investment, Savings.
+
+## Allocation
+
+The three pillars are not separate; they support a single goal, financial freedom.
+
+An **illustrative** split of a $1,000 Freedom Fund: Investment 30% ($300), Savings 40% ($400),
+Discretionary 30% ($300). The 30/40/30 figures are an example, **not a formula**. Each person
+has different income, obligations, goals, and risk tolerance. Readers design their own ratio
+from their real situation.
+
+What cannot be omitted: the Freedom Fund must always flow into **both** the Investment and the
+Savings pillars. These two are mandatory; every plan must include them. The size of the
+proportions, and how any remainder is used, is the person's free choice.
+
+## Discipline is the heart
+
+However you allocate, the deciding factor is not the ratios or any complex strategy, but
+**following your own system consistently for five to ten years or more**. The power of DCA and
+continuous saving shows only when time and compounding do their work.
+
+A system's deepest benefit is dampening emotion — greed in rising markets, fear in volatile
+ones — the true enemies of long-term finance. Those who start early and stay consistent always
+beat those who are clever but start and stop.
+
+> The principle to carry: "Start with a simple system, then do it consistently."

--- a/skills/three-pillar-finance/references/pillar-1-cashflow.md
+++ b/skills/three-pillar-finance/references/pillar-1-cashflow.md
@@ -1,0 +1,19 @@
+# Pillar 1 — Cashflow Management
+
+**Role:** foundation. The pillar the other two stand on.
+
+**What it is.** Knowing how much money flows in and out each month, by recording income and
+expenses consistently. No complex tools required — a notebook or simple app is enough. The key
+is continuity, not sophistication.
+
+**Goal.** To know your true Freedom Fund each month — the number that tells you how much capacity
+you have to invest and save. Without it, every plan is a guess.
+
+**Practice.**
+- Record daily or weekly until it becomes a habit.
+- Review month-end totals.
+- Separate essential spending from discretionary spending.
+- Keep the Freedom Fund firmly positive before moving to Pillars 2 and 3.
+
+**How the lens uses this pillar.** If the person cannot state their monthly Freedom Fund, start
+here. Do not allocate, recommend investments, or design ratios until the number is known and positive.

--- a/skills/three-pillar-finance/references/pillar-2-investment.md
+++ b/skills/three-pillar-finance/references/pillar-2-investment.md
@@ -1,0 +1,22 @@
+# Pillar 2 — Investment
+
+**Role:** offense. Builds compounding returns over time.
+
+**What it is.** Putting your money to work for you — channeling the Freedom Fund into long-term
+returns. Unlike idle cash, invested money can grow through compounding.
+
+**Goal.** To grow wealth faster than saving alone. The key principle: **invest only in what you
+thoroughly understand**. Investing by hype, without understanding the asset, opens the door to
+uncontrollable risk.
+
+**Practice.**
+- Do not rush. Investing is like planting a tree — you cannot force it to grow.
+- Study until you understand, then begin.
+- **DCA (Dollar-Cost Averaging)** — buying steadily every month regardless of price — removes
+  emotion and builds discipline. Ideal for beginners.
+- DCA is one of many methods, **not dogma**. Lump-sum investing, rebalancing, and value investing
+  each have strengths and suit different situations. Choose what fits your goals and temperament.
+
+**How the lens uses this pillar.** Never endorse an asset the person does not understand. When
+asked "what should I buy," redirect to study-first and to the qualities that matter, not a named
+security. When asked about timing or quick wins, redirect to DCA and a 5–10 year horizon.

--- a/skills/three-pillar-finance/references/pillar-3-savings.md
+++ b/skills/three-pillar-finance/references/pillar-3-savings.md
@@ -1,0 +1,22 @@
+# Pillar 3 — Savings (Value Preservation)
+
+**Role:** defense. Plays defense while Investment plays offense.
+
+**What it is.** Not piling up idle cash, but holding **value-preserving assets** to reduce life's
+risks. Idle cash loses purchasing power every year to inflation; good saving protects the value
+of your money from erosion.
+
+**Goal.** To build security and a buffer against risk — so when the unexpected happens, you have
+assets that retain their value to rely on.
+
+**Practice.**
+- Do not fixate on a single asset. Choose by the **qualities** that preserve value: resistance to
+  inflation, reasonable liquidity, broad acceptance.
+- Present-day examples — gold, index funds, bonds, insurance to transfer risk — may change with
+  the times. Study the options available in your era.
+- Diversify so risk is not concentrated in one asset.
+- Maintain a steady savings rate, just as with investing.
+
+**How the lens uses this pillar.** Never let a plan drop Savings in favor of all-in investing.
+When recommending value preservation, describe qualities to look for rather than prescribing one
+named asset.

--- a/skills/three-pillar-finance/references/pitfalls.md
+++ b/skills/three-pillar-finance/references/pitfalls.md
@@ -1,0 +1,21 @@
+# Pitfalls — anti-patterns to catch
+
+Before finalizing advice, check it against these. Each maps to a pillar or to the discipline principle.
+
+- **Skipping Savings (all-in investing).** Offense with no defense. Violates the rule that both
+  Investment and Savings are mandatory.
+
+- **Chasing hype / investing in what you don't understand.** Opens uncontrollable risk. Pillar 2's
+  core warning.
+
+- **Copying someone else's ratio.** A ratio that suits one person may ruin another. Ratios are
+  illustrative; design your own.
+
+- **Stop-start investing.** Kills compounding. The clever-but-inconsistent always lose to the
+  early-and-steady.
+
+- **Hoarding idle cash as "saving".** Inflation erodes it every year. Saving means value-preserving
+  assets, not idle cash.
+
+- **Over-engineering with complex strategy.** Success comes from a simple system done consistently,
+  not from sophistication.


### PR DESCRIPTION
## What this skill does

Adds the **Three-Pillar Personal Finance** skill — a reasoning lens that routes any personal-money conversation through a three-pillar system:

- **Cashflow** (foundation): track what flows in and out; surface the Freedom Fund equation (`Income − Expenses = Freedom Fund`)
- **Investment** (offense): put surplus to work, compounding over time
- **Savings / Value Preservation** (defense): protect against inflation

The skill's non-negotiable principle: **discipline over strategy** — consistent execution of a simple system beats a sophisticated strategy executed irregularly.

## Real-world use case

Users ask AI agents questions like "where should I put my money?", "should I pay off debt or invest?", "how much emergency fund do I need?". Without a grounding framework the answers are generic. This skill anchors the agent's reasoning to the Three-Pillar System so every response is coherent and consistent rather than one-off advice.

## Who uses this workflow

Anyone who wants their AI agent to advise on personal finance using the Three-Pillar framework from the open whitepaper "Foundations of a Personal Finance System: The Three Pillars" by Nonthawit Doungsodsri (MIT License, CC BY 4.0 whitepaper).

## Source repository

https://github.com/nontravis/personal-finance-whitepaper — public, MIT licensed, with the full whitepaper in six languages (EN, TH, ZH, JA, ID, ES) and reference materials used by this skill.

## Attribution

**Inspired by:** Nonthawit Doungsodsri's personal finance whitepaper and Three-Pillar System.