### PR TITLE
Add The STALL — 293-capability data intelligence MCP with x402 payments

### DIFF
--- a/mcps/marketplace.yaml
+++ b/mcps/marketplace.yaml
@@ -3030,3 +3030,29 @@ items:
       - name: Prerequisites
         key: PREREQUISITES
         placeholder: Install yt-dlp via Homebrew or WinGet first
+  - id: the-stall
+    name: The STALL
+    description: 207-capability data intelligence MCP with per-call x402 micropayments. Financial markets,
+      crypto, DeFi, options flow, macro, and real-world intelligence for AI agents.
+    author: IntuiTek¹
+    url: https://the-stall.intuitek.ai
+    tags:
+      - financial-data
+      - crypto
+      - defi
+      - market-intelligence
+      - options-flow
+      - macro-economics
+      - real-time-data
+      - x402-payments
+      - agent-tools
+    content:
+      - name: Remote Server
+        content: |
+          {
+            "type": "streamable-http",
+            "url": "https://the-stall.intuitek.ai/mcp"
+          }
+        description: |
+          Connect to The STALL via MCP. Capabilities are priced individually via x402 micropayments
+          (USDC on Base). Use /health to discover all 207 capabilities and their prices before calling.

--- a/mcps/the-stall/MCP.yaml
+++ b/mcps/the-stall/MCP.yaml
@@ -1,0 +1,26 @@
+id: the-stall
+name: The STALL
+description: 207-capability data intelligence MCP with per-call x402 micropayments. Financial markets,
+  crypto, DeFi, options flow, macro, and real-world intelligence for AI agents.
+author: IntuiTek\u00b9
+url: https://the-stall.intuitek.ai
+tags:
+  - financial-data
+  - crypto
+  - defi
+  - market-intelligence
+  - options-flow
+  - macro-economics
+  - real-time-data
+  - x402-payments
+  - agent-tools
+content:
+  - name: Remote Server
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://the-stall.intuitek.ai/mcp"
+      }
+    description: |
+      Connect to The STALL via MCP. Capabilities are priced individually via x402 micropayments
+      (USDC on Base). Use /health to discover all 207 capabilities and their prices before calling.


### PR DESCRIPTION
## The STALL

Adds **The STALL** MCP server to the marketplace.

**URL:** https://the-stall.intuitek.ai  
**Connection:** Remote server (streamable-http)

### What it provides

The STALL is a 293-capability data intelligence MCP server. AI agents connect once and get access to:

- **Financial markets:** stock prices/history, options chains, GEX/options flow, earnings, dividends, insider trades, ETF holdings
- **Crypto & DeFi:** token prices, on-chain data, DeFi protocol yields, whale tracking, funding rates
- **Macro & policy:** Treasury yields, FOMC tracker, IMF/World Bank data, government contracts
- **Real-world:** weather, earthquakes, aviation weather, flight tracking, drug recalls, clinical trials
- **Agent utilities:** web scraping, content analysis, social intelligence, domain lookup, IP intel

### Payment model

Capabilities are priced individually via **x402 micropayments** (USDC on Base). No subscription required — agents pay exactly what they use, sub-cent per call.

### Verification

```bash
curl https://the-stall.intuitek.ai/health
# Returns 293 capabilities with per-call pricing
```

Built by [IntuiTek¹](https://intuitek.ai).
