### PR TITLE
Add PPXC Find Customers MCP

### DIFF
--- a/mcps/marketplace.yaml
+++ b/mcps/marketplace.yaml
@@ -2246,6 +2246,30 @@ items:
       - name: PostgREST Schema
         key: POSTGREST_SCHEMA
         placeholder: public
+  - id: ppxc-find-customers
+    name: PPXC Find Customers
+    description: Turns short-video comments into customer leads, customer-discovery keywords, lead intent review, and
+      outreach scripts for Douyin, Xiaohongshu, and Kuaishou workflows.
+    author: PPXC
+    url: https://github.com/yuanjian068yuan/ppxc-find-customers
+    tags:
+      - lead-generation
+      - marketing
+      - social-media
+      - customer-discovery
+      - short-video
+      - outreach
+    prerequisites:
+      - Node.js
+    content:
+      - name: NPX
+        prerequisites:
+          - Node.js
+        content: |
+          {
+            "command": "npx",
+            "args": ["-y", "ppxc-leads-mcp"]
+          }
   - id: puppeteer
     name: Puppeteer
     description: Provides browser automation capabilities using Puppeteer, enabling web page interaction, screenshots, and

--- a/mcps/ppxc-find-customers/MCP.yaml
+++ b/mcps/ppxc-find-customers/MCP.yaml
@@ -1,0 +1,23 @@
+id: ppxc-find-customers
+name: PPXC Find Customers
+description: Turns short-video comments into customer leads, customer-discovery keywords, lead intent review, and outreach scripts for Douyin, Xiaohongshu, and Kuaishou workflows.
+author: PPXC
+url: https://github.com/yuanjian068yuan/ppxc-find-customers
+tags:
+  - lead-generation
+  - marketing
+  - social-media
+  - customer-discovery
+  - short-video
+  - outreach
+prerequisites:
+  - Node.js
+content:
+  - name: NPX
+    prerequisites:
+      - Node.js
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "ppxc-leads-mcp"]
+      }


### PR DESCRIPTION
## Summary\n\nAdds PPXC Find Customers as an MCP server entry.\n\n## Use case\n\nPPXC Find Customers helps agents turn short-video comments into customer leads, customer-discovery keywords, lead intent review, and outreach scripts for Douyin, Xiaohongshu, and Kuaishou workflows.\n\n## Links\n\n- Public listing repository: https://github.com/yuanjian068yuan/ppxc-find-customers\n- Setup page: https://opc1.me/download/mcp\n- npm package: https://www.npmjs.com/package/ppxc-leads-mcp\n\n## Checks\n\n- Added `mcps/ppxc-find-customers/MCP.yaml`\n- Regenerated `mcps/marketplace.yaml` with `npx tsx generate-mcps-marketplace.ts`\n- Confirmed the generated marketplace contains the PPXC entry