### PR TITLE
Merge business skill categories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ name: skill-name
 description: A clear description of what the skill does and when it should be used. Use third-person (e.g., "This skill should be used when...").
 license: MIT # Either license or license_path is required, not both
 metadata:
-  category: development # or business-marketing, etc.
+  category: development # or business, etc.
   author: author-name # Optional - who created the skill
   source: # Optional - for skills from external sources
     repository: https://github.com/org/repo
@@ -53,7 +53,7 @@ metadata:
 | `description`                | Yes      | Clear description of what the skill does and when to use it           |
 | `license`                    | Yes*     | SPDX license identifier. Either `license` or `metadata.source.license_path` is required, not both |
 | `metadata`                   | No       | Container for additional metadata                                     |
-| `metadata.category`          | No       | Category for organization (e.g., `development`, `business-marketing`) |
+| `metadata.category`          | No       | Category for organization (e.g., `development`, `business`) |
 | `metadata.author`            | No       | Author or organization name                                           |
 | `metadata.version`           | No       | Semantic version string                                               |
 | `metadata.source`            | No       | Source information for external skills                                |

--- a/skills/competitive-ads-extractor/SKILL.md
+++ b/skills/competitive-ads-extractor/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   etc.) to understand what messaging, problems, and creative approaches are
   working. Helps inspire and improve your own ad campaigns.
 metadata:
-  category: business-marketing
+  category: business
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: competitive-ads-extractor
@@ -298,4 +298,3 @@ Which gets more engagement? (if data available)
 - Discovering new use cases for your product
 - Planning product marketing strategy
 - Inspiring social media content
-

--- a/skills/content-research-writer/SKILL.md
+++ b/skills/content-research-writer/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   feedback on each section. Transforms your writing process from solo effort to
   collaborative partnership.
 metadata:
-  category: communication-writing
+  category: business
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: content-research-writer
@@ -544,4 +544,3 @@ Recommended structure for writing projects:
 - Creating presentation content
 - Writing case studies
 - Developing course outlines
-

--- a/skills/domain-name-brainstormer/SKILL.md
+++ b/skills/domain-name-brainstormer/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   across multiple TLDs (.com, .io, .dev, .ai, etc.). Saves hours of
   brainstorming and manual checking.
 metadata:
-  category: business-marketing
+  category: business
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: domain-name-brainstormer
@@ -217,4 +217,3 @@ After picking a domain:
 - Verify social media handles
 - Research trademark availability
 - Plan brand identity colors/fonts
-

--- a/skills/internal-comms/SKILL.md
+++ b/skills/internal-comms/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   project updates, etc.).
 license: Complete terms in LICENSE.txt
 metadata:
-  category: business-marketing
+  category: business
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: internal-comms

--- a/skills/lead-research-assistant/SKILL.md
+++ b/skills/lead-research-assistant/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   strategies. Perfect for sales, business development, and marketing
   professionals.
 metadata:
-  category: business-marketing
+  category: business
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: lead-research-assistant

--- a/skills/marketplace.yaml
+++ b/skills/marketplace.yaml
@@ -3,15 +3,24 @@ items:
     description: >-
       Extracts and analyzes competitors' ads from ad libraries (Facebook, LinkedIn, etc.) to understand what messaging,
       problems, and creative approaches are working. Helps inspire and improve your own ad campaigns.
-    category: business-marketing
+    category: business
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/competitive-ads-extractor
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/competitive-ads-extractor/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/competitive-ads-extractor.tar.gz
+  - id: content-research-writer
+    description: >-
+      Assists in writing high-quality content by conducting research, adding citations, improving hooks, iterating on
+      outlines, and providing real-time feedback on each section. Transforms your writing process from solo effort to
+      collaborative partnership.
+    category: business
+    githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/content-research-writer
+    rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/content-research-writer/SKILL.md
+    content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/content-research-writer.tar.gz
   - id: domain-name-brainstormer
     description: >-
       Generates creative domain name ideas for your project and checks availability across multiple TLDs (.com, .io,
       .dev, .ai, etc.). Saves hours of brainstorming and manual checking.
-    category: business-marketing
+    category: business
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/domain-name-brainstormer
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/domain-name-brainstormer/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/domain-name-brainstormer.tar.gz
@@ -20,7 +29,7 @@ items:
       A set of resources to help me write all kinds of internal communications, using the formats that my company likes
       to use. The agent should use this skill whenever asked to write some sort of internal communications (status
       reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).
-    category: business-marketing
+    category: business
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/internal-comms
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/internal-comms/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/internal-comms.tar.gz
@@ -29,25 +38,16 @@ items:
       Identifies high-quality leads for your product or service by analyzing your business, searching for target
       companies, and providing actionable contact strategies. Perfect for sales, business development, and marketing
       professionals.
-    category: business-marketing
+    category: business
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/lead-research-assistant
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/lead-research-assistant/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/lead-research-assistant.tar.gz
-  - id: content-research-writer
-    description: >-
-      Assists in writing high-quality content by conducting research, adding citations, improving hooks, iterating on
-      outlines, and providing real-time feedback on each section. Transforms your writing process from solo effort to
-      collaborative partnership.
-    category: communication-writing
-    githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/content-research-writer
-    rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/content-research-writer/SKILL.md
-    content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/content-research-writer.tar.gz
   - id: meeting-insights-analyzer
     description: >-
       Analyzes meeting transcripts and recordings to uncover behavioral patterns, communication insights, and actionable
       feedback. Identifies when you avoid conflict, use filler words, dominate conversations, or miss opportunities to
       listen. Perfect for professionals seeking to improve their communication and leadership skills.
-    category: communication-writing
+    category: business
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/meeting-insights-analyzer
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/meeting-insights-analyzer/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/meeting-insights-analyzer.tar.gz

--- a/skills/meeting-insights-analyzer/SKILL.md
+++ b/skills/meeting-insights-analyzer/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   listen. Perfect for professionals seeking to improve their communication and
   leadership skills.
 metadata:
-  category: communication-writing
+  category: business
   source:
     repository: 'https://github.com/ComposioHQ/awesome-claude-skills'
     path: meeting-insights-analyzer
@@ -334,4 +334,3 @@ today."
 - Coaching direct reports on their communication
 - Analyzing customer calls for sales or support patterns
 - Studying negotiation tactics and outcomes
-


### PR DESCRIPTION
## Summary
- Merge `business-marketing` and `communication-writing` skill categories into `business`
- Regenerate `skills/marketplace.yaml` from skill frontmatter
- Update category examples in `AGENTS.md`

## Validation
- `npx tsx generate-skill-marketplace.ts` from `bin/`
- `git diff --check -- AGENTS.md skills/marketplace.yaml skills/competitive-ads-extractor/SKILL.md skills/domain-name-brainstormer/SKILL.md skills/internal-comms/SKILL.md skills/lead-research-assistant/SKILL.md skills/content-research-writer/SKILL.md skills/meeting-insights-analyzer/SKILL.md`
- Confirmed no `business-marketing` or `communication-writing` references remain in root `AGENTS.md` or `skills/`
