### PR TITLE
Hide generated marketplace files in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+agents/marketplace.yaml linguist-generated=true
+mcps/marketplace.yaml linguist-generated=true
+modes/marketplace.yaml linguist-generated=true
+skills/marketplace.yaml linguist-generated=true


### PR DESCRIPTION
## What changed

- mark all four generated `marketplace.yaml` files as `linguist-generated`
- collapse these generated files by default in GitHub pull request diffs

## Validation

- verified the attributes target the generated marketplace files under `agents`, `mcps`, `modes`, and `skills`
