### PR TITLE
Add custom data investigation skills

### DIFF
--- a/skills/data-investigation/SKILL.md
+++ b/skills/data-investigation/SKILL.md
@@ -196,5 +196,4 @@ Every completed investigation should leave behind:
 
 ## Related Skills
 
-- Use `mailing-list-sql` when the output is a user selection query for marketing or outreach.
 - Use `answering-natural-language-questions-with-dbt` when the goal is answering a business question rather than debugging why analysis or metrics disagree.

--- a/skills/data-investigation/SKILL.md
+++ b/skills/data-investigation/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: data-investigation
+description: >-
+  A workflow for conducting rigorous, reproducible data investigations and
+  ad-hoc analyses. This skill should be used when investigating a business
+  question, explaining a metric anomaly, validating a hypothesis, performing
+  root cause analysis, or preparing a one-off investigation dashboard or memo.
+license: MIT
+metadata:
+  category: development
+  author: Pedro / Kilo Code
+---
+
+# Data Investigation
+
+Use this skill to produce investigations that are fast, correct, reproducible,
+and communicate a clear conclusion rather than a pile of charts.
+
+## Purpose
+
+Every investigation should be answerable in one sentence before the first SQL
+query is written.
+
+## Phase 1: Frame Before Querying
+
+### 1. Write the one-sentence answer first
+
+Before writing any SQL, write the sentence the conclusion is expected to be.
+
+Example: `The cohort size gap is a definition problem rather than a product behavior problem.`
+
+If the sentence cannot be written, the question is not yet understood.
+
+### 2. Classify the investigation type
+
+| Type | Trigger | Approach |
+|---|---|---|
+| Gap analysis | Why do A and B not match? | Establish the gap, localize it, explain it |
+| Root cause | Why did this metric change? | Confirm real, isolate segment, align timing, validate mechanism |
+| Hypothesis test | Is X causing Y? | Define what must be true, test sub-claims, confirm or reject |
+| Feasibility check | Is this number trustworthy? | Check grain, joins, nulls, definition overlap |
+
+### 3. State 2-3 competing hypotheses before querying
+
+Never investigate with a single hypothesis. That creates confirmation bias.
+
+Order hypotheses by plausibility and note which one is currently expected to be
+correct and why.
+
+## Phase 2: Build Queries In Escalating Specificity
+
+### 1. Establish first, explain second
+
+Step 1 always confirms the anomaly is real and measures its magnitude.
+Do not jump to cause until the effect is confirmed.
+
+```sql
+select
+    <time_bucket>,
+    <source_a_count> as metric_a,
+    <source_b_count> as metric_b,
+    <source_a_count> - <source_b_count> as gap,
+    round(100.0 * (<source_a_count> - <source_b_count>) / nullif(<source_a_count>, 0), 1) as pct_gap
+from ...
+order by 1
+```
+
+### 2. Localize by breaking one dimension at a time
+
+After confirming the gap, break it down along one dimension per step:
+- By time: when did it appear?
+- By segment: who is affected?
+- By signal/source: which path is missing?
+
+### 3. Align timing with upstream changes
+
+Once the anomaly start date is known, check:
+- git commits to relevant models, ETL jobs, or application code
+- schema migrations or source changes
+- metric definition changes
+- external events such as launches, campaigns, or pricing changes
+
+A credible root cause must explain why the metric changed when it did.
+
+### 4. Validate the mechanism
+
+After identifying a candidate cause, confirm it mechanically:
+- Does the affected population match the predicted population?
+- What does the counterfactual look like?
+- Does a second independent signal support the explanation?
+
+Do not stop at correlation.
+
+### 5. Quantify each hypothesis before concluding
+
+For every candidate explanation, produce a number.
+
+Examples:
+- `H1 accounts for 1,240 users`
+- `H2 accounts for 1,050 users`
+
+If a hypothesis cannot be quantified, it is not yet validated.
+
+## Phase 3: SQL Hygiene Rules
+
+### Use stable time bounds for investigations
+
+Investigation SQL should be reproducible. Favor fixed bounds over rolling
+windows unless the analysis is intentionally operational and evergreen.
+
+```sql
+-- Prefer fixed investigation scope
+where created_at >= '2026-02-16'
+  and created_at < '2026-04-04'
+```
+
+### Add explicit grain comments in important CTEs
+
+```sql
+-- grain: one row per user
+with users as (
+    ...
+)
+```
+
+### Prefer named comparison outputs over raw aggregates
+
+Bad:
+
+```sql
+select count(*) from ...
+```
+
+Better:
+
+```sql
+select
+    count(*) as users_in_scope,
+    count(distinct org_id) as orgs_in_scope
+from ...
+```
+
+### Keep diagnostic queries small and discardable
+
+Diagnostic SQL exists to answer one question. Do not build giant reusable
+queries too early.
+
+## Phase 4: Communication Rules
+
+### Lead with the answer
+
+The first sentence of the written output should state the conclusion.
+
+Bad:
+
+`I looked at several possible explanations for the discrepancy.`
+
+Good:
+
+`The discrepancy is caused by internal users being excluded from the dashboard query but included in the warehouse baseline.`
+
+### Separate evidence from interpretation
+
+Use a structure like:
+
+1. Conclusion
+2. Evidence
+3. Why alternative hypotheses were rejected
+4. Recommended next action
+
+### Include the limiting assumption
+
+Every investigation should state the biggest assumption that could change the
+answer.
+
+Example:
+
+`This conclusion assumes backend event timestamps are complete for the affected week; if ingestion was delayed, the gap may be overstated.`
+
+## Phase 5: Output Standard
+
+Every completed investigation should leave behind:
+
+1. One-sentence answer
+2. Final supporting SQL or notebook
+3. A note on rejected hypotheses
+4. Any follow-up question or unresolved ambiguity
+
+## Common Failure Modes
+
+- Treating a metric definition dispute as a product issue
+- Comparing sources with different grain or freshness
+- Accepting the first plausible explanation without quantification
+- Writing one giant query too early
+- Ending with charts instead of an answer
+
+## Related Skills
+
+- Use `mailing-list-sql` when the output is a user selection query for marketing or outreach.
+- Use `answering-natural-language-questions-with-dbt` when the goal is answering a business question rather than debugging why analysis or metrics disagree.

--- a/skills/debugging-snowflake-queries/SKILL.md
+++ b/skills/debugging-snowflake-queries/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: debugging-snowflake-queries
 description: This skill should be used when a user needs help debugging a Snowflake SQL query, understanding a Snowflake query failure, isolating incorrect results, fixing joins or filters, diagnosing performance problems, or turning a vague warehouse error into a concrete root cause and corrected query. It is a standalone Snowflake query debugging skill for ad hoc SQL work across databases, schemas, and environments.
+metadata:
+  category: development
 ---
 
 # Debugging Snowflake Queries

--- a/skills/debugging-snowflake-queries/SKILL.md
+++ b/skills/debugging-snowflake-queries/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: debugging-snowflake-queries
+description: This skill should be used when a user needs help debugging a Snowflake SQL query, understanding a Snowflake query failure, isolating incorrect results, fixing joins or filters, diagnosing performance problems, or turning a vague warehouse error into a concrete root cause and corrected query. It is a standalone Snowflake query debugging skill for ad hoc SQL work across databases, schemas, and environments.
+---
+
+# Debugging Snowflake Queries
+
+Debug Snowflake SQL systematically: reproduce the failure, classify the problem, isolate the smallest failing unit, verify grain and joins, and only then rewrite the query.
+
+## When to Use
+
+- Diagnose Snowflake errors such as `SQL compilation error`, `invalid identifier`, `object does not exist`, `ambiguous column`, cast failures, permission failures, or timeouts
+- Debug queries that run but return the wrong count, duplicate rows, empty results, stale-looking data, or impossible percentages
+- Investigate performance problems such as long scans, warehouse issues, or unexpectedly expensive joins
+- Review an ad hoc SQL query and explain how to make it correct and reproducible
+
+## Do Not Use For
+
+- Template or application-layer SQL generation failures where no Snowflake SQL is actually being debugged
+- General business investigations where the main task is answering the question rather than debugging the query itself
+
+## Workflow
+
+1. Reproduce the exact failing query or reconstruct the smallest equivalent query.
+2. Classify the issue before changing SQL:
+   - compile/name-resolution
+   - permissions/environment
+   - type/cast/null semantics
+   - join/grain/result correctness
+   - performance/scan/warehouse
+   - stale or incomplete upstream data
+3. Reduce the query to the smallest failing component:
+   - one CTE at a time
+   - one join at a time
+   - one computed expression at a time
+   - one filter at a time
+4. Verify object existence, schema, and exact column names before assuming anything.
+5. State the grain of each input and intermediate result explicitly.
+6. Validate counts and null rates around every join boundary.
+7. When a query is logically wrong but syntactically valid, prove the failure mode with a targeted counterexample or diagnostic query.
+8. Only after isolating the root cause, rewrite the full query.
+
+## Core Rules
+
+- Prefer minimal diagnostic queries over speculative rewrites.
+- Keep each debugging step falsifiable: each query should answer one question.
+- Never assume two tables can be joined just because they share similarly named IDs.
+- Treat row explosion as a grain mismatch until proven otherwise.
+- Treat zero rows as a filter, time-window, or join-key problem before blaming missing data.
+- Treat surprising percentages as denominator scope problems before blaming arithmetic.
+- Use fully qualified names when working outside dbt macros or when environment ambiguity is possible.
+- Check for soft-delete columns and freshness/ingestion timestamps when backend mirrors are involved.
+- For large fact tables, tighten the date filter first and inspect scan behavior before running broad diagnostics.
+
+## References
+
+Load these references as needed:
+
+- `references/debugging-playbook.md`
+  Use for the end-to-end workflow, diagnostic query templates, and how to narrow a failure.
+- `references/error-taxonomy.md`
+  Use to map common Snowflake error messages to likely causes and next checks.
+- `references/result-correctness-checklist.md`
+  Use when the query runs but results look wrong: duplicates, drops, denominator mistakes, stale data.
+- `references/query-patterns-and-failure-modes.md`
+  Use for concrete warehouse-agnostic examples of common failure modes and how to correct them.
+
+## Expected Output
+
+When returning a debugging answer:
+
+1. State the likely root cause in one sentence.
+2. Show the minimal diagnostic evidence.
+3. Provide the corrected query or exact fix.
+4. Note any remaining assumptions, especially around grain, environment, or upstream freshness.

--- a/skills/debugging-snowflake-queries/references/debugging-playbook.md
+++ b/skills/debugging-snowflake-queries/references/debugging-playbook.md
@@ -1,0 +1,301 @@
+# Snowflake Query Debugging Playbook
+
+## 1. Start from the exact failure
+
+Capture one of these before changing anything:
+
+- Exact error text
+- Exact query text
+- Exact wrong result and why it is wrong
+- Exact runtime symptom: timeout, warehouse suspended, empty result, duplicates, stale data
+
+If the user only gives a description, reconstruct the smallest plausible query that matches it.
+
+## 2. Classify the issue
+
+### A. Compile or name-resolution failures
+
+Examples:
+
+- `SQL compilation error`
+- `Object does not exist`
+- `invalid identifier`
+- `ambiguous column name`
+- `unexpected ','` or parser errors
+
+First checks:
+
+- Is the table/view name fully qualified?
+- Is the schema correct for this environment?
+- Does the column actually exist on this relation?
+- Did a CTE alias shadow a table alias?
+- Did a SELECT alias get referenced in the wrong clause?
+
+### B. Permissions or environment failures
+
+Examples:
+
+- `not authorized`
+- warehouse not available
+- cannot operate on object in current role
+
+First checks:
+
+- Current database, schema, warehouse, and role
+- Whether the object exists but is inaccessible
+- Whether the query is pointing at prod vs dev vs personal schema incorrectly
+
+### C. Type, cast, and null-semantics failures
+
+Examples:
+
+- `Numeric value ... is not recognized`
+- date cast errors
+- division by zero
+- silent null propagation
+
+First checks:
+
+- Which expression fails when isolated?
+- Are mixed types being compared or coalesced?
+- Should `try_to_*` be used for diagnosis?
+- Is the denominator scoped correctly and wrapped with `nullif()`?
+
+### D. Result correctness failures
+
+Examples:
+
+- Count too high
+- Count too low
+- duplicated rows
+- empty results
+- percentages over 100%
+
+First checks:
+
+- What is the intended grain?
+- Which join changed row count?
+- Which filter removes the expected rows?
+- Are two definitions being compared as if they were the same metric?
+
+### E. Performance failures
+
+Examples:
+
+- query times out
+- query scans too much data
+- warehouse scales unexpectedly
+
+First checks:
+
+- Add or tighten date filters on large facts
+- Remove unnecessary columns and joins
+- Run `EXPLAIN` where appropriate
+- Check whether a pre-aggregated mart already exists
+
+### F. Upstream freshness or ingestion failures
+
+Examples:
+
+- one day looks implausibly low
+- table is present but data seems delayed
+- backend mirror disagrees with dbt mart
+
+First checks:
+
+- Compare source vs transformed table for the affected window
+- Inspect ingestion or `_snowflake_inserted_at` style timestamps if present
+- Check whether the model is intraday-current or batch-lagged
+
+## 3. Reduce the query
+
+Strip the query down aggressively.
+
+### Pattern: isolate one CTE
+
+```sql
+with base as (
+    -- original base logic only
+)
+select *
+from base
+limit 100;
+```
+
+### Pattern: measure row counts by stage
+
+```sql
+with a as (...),
+b as (...),
+c as (...)
+select 'a' as stage, count(*) as rows from a
+union all
+select 'b' as stage, count(*) as rows from b
+union all
+select 'c' as stage, count(*) as rows from c;
+```
+
+### Pattern: inspect one join boundary
+
+```sql
+with left_side as (...),
+right_side as (...)
+select
+    count(*) as rows_after_join,
+    count(distinct l.join_key) as left_keys,
+    count(distinct r.join_key) as right_keys
+from left_side l
+left join right_side r
+    on l.join_key = r.join_key;
+```
+
+## 4. Verify grain explicitly
+
+Write grain comments or notes while debugging.
+
+Examples:
+
+- one row per user
+- one row per user per day
+- one row per invoice
+- one row per request id
+
+Most bad joins are really grain mismatches:
+
+- user joined to user-day
+- invoice joined to payment-attempt
+- org joined to org-member without re-aggregation
+
+## 5. Count before and after every join
+
+Use diagnostics like:
+
+```sql
+with left_side as (...),
+right_side as (...)
+select
+    count(*) as rows_after_join,
+    count(distinct l.primary_key) as left_entities_after_join,
+    count(distinct case when r.join_key is null then l.primary_key end) as unmatched_left_entities
+from left_side l
+left join right_side r
+    on l.join_key = r.join_key;
+```
+
+If `rows_after_join` exceeds `left_entities_after_join` unexpectedly, suspect one-to-many inflation.
+
+## 6. Debug zero-row outputs
+
+Check in this order:
+
+1. Does the base table have rows in the time window?
+2. Does each filter individually preserve rows?
+3. Does the join key exist on both sides?
+4. Is the timestamp in the timezone or grain you think it is?
+5. Are soft-deleted rows being excluded correctly?
+
+Diagnostic pattern:
+
+```sql
+select count(*) from some_table where created_at >= '2026-06-01';
+select count(*) from some_table where created_at >= '2026-06-01' and some_flag = true;
+select count(*) from some_table where created_at >= '2026-06-01' and some_flag = true and user_id is not null;
+```
+
+## 7. Debug duplicates and inflated counts
+
+Check whether the primary entity appears more than once:
+
+```sql
+select
+    primary_key,
+    count(*) as cnt
+from suspicious_cte
+group by 1
+having count(*) > 1
+order by cnt desc
+limit 50;
+```
+
+If duplicates are expected on the right side, aggregate before joining.
+
+```sql
+with right_agg as (
+    select
+        join_key,
+        max(some_value) as some_value
+    from right_side
+    group by 1
+)
+select ...
+from left_side l
+left join right_agg r
+    on l.join_key = r.join_key;
+```
+
+## 8. Debug stale or incomplete data
+
+Compare adjacent days or source-vs-model counts.
+
+```sql
+select
+    date_trunc('day', created_at) as day,
+    count(*) as rows
+from source_table
+where created_at >= '2026-06-01'
+group by 1
+order by 1;
+```
+
+If one day is far below normal, compare the upstream source, transformed mart, and any ingestion timestamp fields.
+
+## 9. Debug cast and type issues
+
+Find the bad values before coercing everything.
+
+```sql
+select raw_value
+from some_table
+where try_to_number(raw_value) is null
+  and raw_value is not null
+limit 100;
+```
+
+```sql
+select raw_date
+from some_table
+where try_to_timestamp_ntz(raw_date) is null
+  and raw_date is not null
+limit 100;
+```
+
+Use `try_to_*` for diagnosis, then decide whether to clean, filter, or cast.
+
+## 10. Debug performance
+
+For large fact tables:
+
+- add date filters first
+- select only columns needed for the diagnostic
+- test the base CTE alone
+- join only after the base row count looks plausible
+- avoid `select *` while debugging scan-heavy tables
+
+If needed, inspect the plan:
+
+```sql
+explain using text
+select ...;
+```
+
+Look for full scans, late filters, or fan-out joins.
+
+## 11. Final rewrite rules
+
+When delivering the fix:
+
+- keep the final query as small as possible
+- preserve the proven filters and join constraints
+- include `nullif()` on percentage denominators
+- comment non-obvious grain or assumptions
+- mention if the real root cause was upstream freshness, not SQL logic

--- a/skills/debugging-snowflake-queries/references/error-taxonomy.md
+++ b/skills/debugging-snowflake-queries/references/error-taxonomy.md
@@ -1,0 +1,141 @@
+# Snowflake Error Taxonomy
+
+## `Object does not exist` / `does not exist or not authorized`
+
+Likely causes:
+
+- wrong database or schema
+- wrong environment (`prod` vs personal/dev schema)
+- typo in relation name
+- role lacks access
+- view points to an upstream relation that moved
+
+Checks:
+
+- fully qualify the relation
+- list or describe the object in the target schema
+- confirm role and warehouse context
+
+## `invalid identifier`
+
+Likely causes:
+
+- misspelled column
+- column exists on a different table alias
+- referring to a SELECT alias from `where` instead of `qualify` / outer query
+- quoted identifier mismatch
+
+Checks:
+
+- describe the relation
+- qualify the column with the alias
+- isolate the expression into a smaller query
+
+## `ambiguous column name`
+
+Likely causes:
+
+- same column name on multiple joined relations
+- unqualified select, filter, order, or group by field
+
+Fix:
+
+- qualify every shared column with its alias
+
+## Parser errors like `unexpected ','`, `unexpected ')'`, `syntax error line ...`
+
+Likely causes:
+
+- malformed CTE chain
+- trailing comma
+- dialect mismatch from copied SQL
+- reserved word used as alias
+
+Checks:
+
+- strip to the failing CTE
+- rebuild one clause at a time
+
+## `Numeric value ... is not recognized`
+
+Likely causes:
+
+- non-numeric strings in a numeric cast
+- currency or punctuation embedded in values
+- mixed-type `coalesce`
+
+Checks:
+
+- inspect `try_to_number()` failures
+- standardize types before arithmetic
+
+## Division by zero or implausible percentages
+
+Likely causes:
+
+- denominator can be zero
+- denominator population differs from numerator population
+
+Fix:
+
+- use `nullif(denominator, 0)`
+- verify denominator grain and scope
+
+## Query runs but returns duplicates
+
+Likely causes:
+
+- one-to-many join without prior aggregation
+- duplicate source rows at the assumed key
+- joining on non-unique natural keys
+
+Checks:
+
+- count duplicates by key on both sides
+- aggregate right side before join if the output grain requires one row per key
+
+## Query runs but returns zero rows
+
+Likely causes:
+
+- too-tight or wrong-grain date filter
+- join keys do not overlap
+- timestamps compared in different timezones or grains
+- soft-delete filter removes all rows
+
+Checks:
+
+- test filters one by one
+- inspect overlap of join keys
+- compare raw timestamp vs `::date` behavior
+
+## Timeout or excessive runtime
+
+Likely causes:
+
+- unbounded scan on a large fact table
+- heavy join before filtering
+- distinct or window over too-broad input
+- warehouse too small or suspended/resumed unexpectedly
+
+Checks:
+
+- constrain time range
+- reduce columns
+- run the base CTE first
+- inspect `EXPLAIN`
+
+## Query looks correct but data is stale or incomplete
+
+Likely causes:
+
+- upstream ingestion lag
+- incremental model not yet caught up
+- mirror/outage backfill landed late
+- reading a transformed table when the source is fresher
+
+Checks:
+
+- compare source vs downstream counts for affected dates
+- inspect load timestamps if available
+- verify table cadence assumptions

--- a/skills/debugging-snowflake-queries/references/query-patterns-and-failure-modes.md
+++ b/skills/debugging-snowflake-queries/references/query-patterns-and-failure-modes.md
@@ -1,0 +1,123 @@
+# Query Patterns and Failure Modes
+
+Use these as generic examples of how Snowflake query failures happen in real warehouse work.
+
+## 1. Wrong environment or schema
+
+Failure mode:
+
+- The query points at the wrong database, schema, or environment.
+- The object exists somewhere else, so the SQL looks reasonable but fails or returns stale data.
+
+Transferable lesson:
+
+- A large share of `object does not exist` and stale-result bugs are environment bugs, not logic bugs.
+- Verify the exact relation path before rewriting the query.
+
+## 2. Filter column lives on a metadata or enrichment table
+
+Failure mode:
+
+- A query applies a filter using a column that does not live on the main fact table.
+- The column actually comes from a side table joined by request id, event id, or some other surrogate key.
+
+Generic pattern:
+
+```sql
+from fact_table f
+left join fact_metadata m
+    on f.id = m.id
+where coalesce(m.some_flag, false) = false
+```
+
+Transferable lesson:
+
+- When a filter seems semantically right but the column is missing, check whether it belongs to an enrichment table rather than the core fact.
+
+## 3. Wrong source for the analytical question
+
+Failure mode:
+
+- The query is syntactically correct, but the chosen source has partial coverage, different semantics, or lag that makes the answer wrong.
+
+Transferable lesson:
+
+- If the business answer is implausible, re-check source suitability before rewriting aggregations.
+- Coverage problems often look like logic bugs.
+
+## 4. Identity scope mismatch
+
+Failure mode:
+
+- Counts are inflated or deflated because guest, anonymous, test, internal, or unresolved identities are mixed with the intended population.
+
+Transferable lesson:
+
+- Bad counts often come from entity scope, not arithmetic.
+- Always ask which entity classes should be included or excluded.
+
+## 5. Freshness issue masquerading as a metric change
+
+Failure mode:
+
+- One day or hour drops sharply because one upstream input is incomplete while another is current.
+
+Transferable lesson:
+
+- Sudden cliffs are often ingestion or freshness issues.
+- Compare source-vs-downstream row counts by time bucket before changing the metric logic.
+
+## 6. Historical query copied after naming drift
+
+Failure mode:
+
+- A copied query references an old database name, schema name, or renamed object.
+
+Transferable lesson:
+
+- Historical SQL ages badly.
+- Inspect current warehouse structure instead of trusting old snippets.
+
+## 7. Bridge table required for cross-system joins
+
+Failure mode:
+
+- Two systems represent the same entity with different IDs.
+- The query tries to infer the relationship directly from string patterns or naming similarity.
+
+Transferable lesson:
+
+- If systems use different identifiers, look for a canonical mapping table first.
+- Do not improvise cross-system joins unless the mapping is proven.
+
+## 8. Soft-delete or CDC tombstones distort results
+
+Failure mode:
+
+- Mirrored operational tables contain deleted rows or tombstones that remain queryable.
+
+Transferable lesson:
+
+- If mirrored-source counts exceed expectations, inspect delete markers, CDC status fields, or load-state columns.
+
+## 9. One-to-many enrichment inflates facts
+
+Failure mode:
+
+- A fact table is joined to an enrichment table with multiple rows per key.
+- Counts, sums, or distincts are inflated after the join.
+
+Transferable lesson:
+
+- Aggregate the enrichment side to one row per join key before joining when the output grain requires it.
+
+## 10. Date filter applied at the wrong grain
+
+Failure mode:
+
+- Filtering on `timestamp >= ...` in one table and `date >= ...` in another causes mismatched populations.
+- Truncation or timezone conversion silently removes expected rows.
+
+Transferable lesson:
+
+- Align all inputs to the same time grain and boundary before comparing counts.

--- a/skills/debugging-snowflake-queries/references/result-correctness-checklist.md
+++ b/skills/debugging-snowflake-queries/references/result-correctness-checklist.md
@@ -1,0 +1,90 @@
+# Result Correctness Checklist
+
+Use this when SQL executes successfully but the answer is wrong or suspicious.
+
+## Grain
+
+- What is the intended grain of the final output?
+- What is the grain of each input table?
+- Does every join preserve the intended grain?
+
+## Population
+
+- Are numerator and denominator drawn from the same entity set?
+- Are anonymous, internal, soft-deleted, or test rows excluded consistently?
+- Are org and personal rows being mixed accidentally?
+
+## Time window
+
+- Are all inputs filtered to the same time grain and range?
+- Is one table event-time and another load-time?
+- Is the query comparing `timestamp` to `date` in a way that truncates unexpectedly?
+
+## Join quality
+
+- Does the join key have one row per entity on both sides?
+- Is there hidden one-to-many inflation?
+- Would pre-aggregating the right side change the result materially?
+
+## Null behavior
+
+- Are left joins followed by `where right_table.col = ...` that accidentally turn them into inner joins?
+- Are `coalesce()` defaults hiding missingness?
+- Are null-denominator rows supposed to disappear or remain null?
+
+## Duplicates
+
+- Does the primary entity appear more than once after each join?
+- Are duplicate rows coming from the source or from the query logic?
+
+## Freshness
+
+- Is the source complete for the affected dates?
+- Is the downstream model known to lag?
+- Did an outage or delayed ingest create an apparent product anomaly?
+
+## Definitions
+
+- Are two metrics being compared even though they encode different business rules?
+- Is a backend event being treated as equivalent to user activity?
+- Is first-event logic being compared to any-event logic?
+
+## Minimal diagnostics to run
+
+```sql
+-- row counts by day
+select date_trunc('day', created_at) as day, count(*)
+from some_table
+where created_at >= '2026-06-01'
+group by 1
+order by 1;
+```
+
+```sql
+-- duplicate keys
+select key, count(*)
+from some_cte
+group by 1
+having count(*) > 1
+order by 2 desc
+limit 50;
+```
+
+```sql
+-- unmatched left entities
+select count(distinct l.key) as unmatched
+from left_side l
+left join right_side r
+    on l.key = r.key
+where r.key is null;
+```
+
+```sql
+-- denominator sanity
+select
+    count(*) as rows,
+    count_if(denominator = 0) as zero_denominator_rows,
+    min(denominator) as min_denominator,
+    max(denominator) as max_denominator
+from suspicious_result;
+```

--- a/skills/marketplace.yaml
+++ b/skills/marketplace.yaml
@@ -256,6 +256,16 @@ items:
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/dbt-migration
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/dbt-migration/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/dbt-migration.tar.gz
+  - id: debugging-snowflake-queries
+    description: >-
+      This skill should be used when a user needs help debugging a Snowflake SQL query, understanding a Snowflake query
+      failure, isolating incorrect results, fixing joins or filters, diagnosing performance problems, or turning a vague
+      warehouse error into a concrete root cause and corrected query. It is a standalone Snowflake query debugging skill
+      for ad hoc SQL work across databases, schemas, and environments.
+    category: development
+    githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/debugging-snowflake-queries
+    rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/debugging-snowflake-queries/SKILL.md
+    content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/debugging-snowflake-queries.tar.gz
   - id: deploy-to-vercel
     description: >-
       Deploy applications and websites to Vercel. Use when the user requests deployment actions like "deploy my app",
@@ -369,12 +379,3 @@ items:
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/webapp-testing
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/webapp-testing/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/webapp-testing.tar.gz
-  - id: debugging-snowflake-queries
-    description: >-
-      This skill should be used when a user needs help debugging a Snowflake SQL query, understanding a Snowflake query
-      failure, isolating incorrect results, fixing joins or filters, diagnosing performance problems, or turning a vague
-      warehouse error into a concrete root cause and corrected query. It is a standalone Snowflake query debugging skill
-      for ad hoc SQL work across databases, schemas, and environments.
-    githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/debugging-snowflake-queries
-    rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/debugging-snowflake-queries/SKILL.md
-    content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/debugging-snowflake-queries.tar.gz

--- a/skills/marketplace.yaml
+++ b/skills/marketplace.yaml
@@ -231,6 +231,15 @@ items:
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/create-pull-request
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/create-pull-request/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/create-pull-request.tar.gz
+  - id: data-investigation
+    description: >-
+      A workflow for conducting rigorous, reproducible data investigations and ad-hoc analyses. This skill should be
+      used when investigating a business question, explaining a metric anomaly, validating a hypothesis, performing root
+      cause analysis, or preparing a one-off investigation dashboard or memo.
+    category: development
+    githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/data-investigation
+    rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/data-investigation/SKILL.md
+    content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/data-investigation.tar.gz
   - id: dbt
     description: >-
       Skills for analytics engineering with dbt - building models, writing tests, querying the semantic layer,
@@ -360,3 +369,12 @@ items:
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/webapp-testing
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/webapp-testing/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/webapp-testing.tar.gz
+  - id: debugging-snowflake-queries
+    description: >-
+      This skill should be used when a user needs help debugging a Snowflake SQL query, understanding a Snowflake query
+      failure, isolating incorrect results, fixing joins or filters, diagnosing performance problems, or turning a vague
+      warehouse error into a concrete root cause and corrected query. It is a standalone Snowflake query debugging skill
+      for ad hoc SQL work across databases, schemas, and environments.
+    githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/debugging-snowflake-queries
+    rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/debugging-snowflake-queries/SKILL.md
+    content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/debugging-snowflake-queries.tar.gz


### PR DESCRIPTION
## Motivation

The marketplace did not have a strong local skill for analytical investigations or a focused skill for debugging ad hoc Snowflake SQL. Those are common tasks in warehouse work, and they benefit from explicit workflows rather than generic prompting. This change closes that gap by adding two local skills that make those tasks easier to run in a repeatable way.

## Implementation

This PR adds `data-investigation` as a local skill for framing and running analytical investigations. It pushes the user to define the expected answer early, test competing explanations, validate grain and timing, and communicate a conclusion with supporting evidence.

It also adds `debugging-snowflake-queries` as a local skill for isolating Snowflake query failures and incorrect results. The main skill file defines the debugging workflow, and the bundled references cover the playbook, common error types, result correctness checks, and recurring failure modes.

## Testing

I verified that both skill directories contain a valid `SKILL.md`. I also verified that `debugging-snowflake-queries` includes the expected reference files and that the branch contains only these local skill additions.

## Notes

These skills are intentionally shipped separately from the external import batch because they are local custom skills rather than imported marketplace mirrors.