### PR TITLE
Add VS Code extension suggestions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,7 @@ metadata:
   source:
     repository: 'https://github.com/cline/cline'
     path: .cline/skills/create-pull-request
+    license_path: LICENSE
 ---
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ metadata:
   category: development
   author: your-github-username
   suggest_for:
-    extension:
+    filename:
       - "*.component.ts"
   source:
     repository: https://github.com/yourname/your-skill-repo
@@ -138,12 +138,13 @@ metadata:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `metadata.suggest_for.extension` | No | Non-empty list of patterns that make this skill highly probable from the filename alone; prefer distinctive forms such as `"*.component.ts"` and omit broad patterns such as `"*.ts"` |
+| `metadata.suggest_for.filename` | No | Non-empty list of patterns that make this skill highly probable from the filename alone; prefer distinctive forms such as `"*.component.ts"` and omit broad patterns such as `"*.ts"` |
+| `metadata.suggest_for.vscode_extension` | No | Non-empty list of exact VS Code extension IDs that strongly indicate this skill is relevant, such as `"ms-toolsai.jupyter"` |
 | `metadata.source.repository` | **Yes** (for contributed skills) | URL to the GitHub repository containing your skill |
 | `metadata.source.path` | **Yes** (for contributed skills) | Path within the repository to the skill directory |
 | `metadata.source.license_path` | **Yes** (for contributed skills) | Path to the LICENSE file in the source repo |
 
-Suggestion patterns are intentionally not exhaustive. A format being supported as input or output is not enough to add it: for example, a generic Markdown or audio file does not imply a writing or meeting-analysis task.
+Suggestion patterns are intentionally not exhaustive. A format being supported as input or output is not enough to add it: for example, a generic Markdown or audio file does not imply a writing or meeting-analysis task. Likewise, only list a VS Code extension when its installation strongly indicates the exact skill is relevant. A `suggest_for` object must contain at least one of `filename` or `vscode_extension`.
 
 ### Real-World Examples
 
@@ -295,7 +296,7 @@ author: author-name
 url: https://github.com/org/repo
 category: development
 suggest_for:
-  extension:
+  filename:
     - "*.i64"
 prerequisites:
   - Required software or accounts
@@ -327,7 +328,8 @@ parameters:
 | `author` | Yes | Author or organization name |
 | `url` | Yes | Link to the MCP server repository |
 | `category` | Yes | Primary category: `business`, `data`, `development`, `observability`, `productivity`, `search`, or `web-automation` |
-| `suggest_for.extension` | No | Non-empty list of patterns that make this MCP server highly probable from the filename alone; prefer proprietary formats such as `"*.i64"` and omit broad patterns such as `"*.php"` |
+| `suggest_for.filename` | No | Non-empty list of patterns that make this MCP server highly probable from the filename alone; prefer proprietary formats such as `"*.i64"` and omit broad patterns such as `"*.php"` |
+| `suggest_for.vscode_extension` | No | Non-empty list of exact VS Code extension IDs that strongly indicate this MCP server is relevant, such as `"ms-toolsai.jupyter"` for Jupyter |
 | `prerequisites` | No | Required software or accounts |
 | `content` | Yes | Installation configuration(s) |
 | `parameters` | No | User-configurable parameters |
@@ -344,7 +346,7 @@ Choose the single category that best represents how users will discover the MCP.
 
 Propose a new category only when several MCPs share a distinct primary purpose that does not fit an existing category.
 
-Suggestion patterns are intentionally not exhaustive. Do not list every format an MCP can open; add only formats that strongly identify that exact MCP, such as `"*.ipynb"` for Jupyter.
+Suggestion patterns are intentionally not exhaustive. Do not list every format an MCP can open; add only filenames or VS Code extensions that strongly identify that exact MCP, such as `"*.ipynb"` or `"ms-toolsai.jupyter"` for Jupyter. A `suggest_for` object must contain at least one of `filename` or `vscode_extension`.
 
 ### Transport Types
 

--- a/bin/generate-mcps-marketplace.ts
+++ b/bin/generate-mcps-marketplace.ts
@@ -30,18 +30,51 @@ function validateSuggestFor(value: unknown, mcpId: string): void {
     throw new Error(`${mcpId}: suggest_for must be an object`);
   }
 
-  const extensions = (value as { extension?: unknown }).extension;
+  const suggestFor = value as Record<string, unknown>;
+  const unknownKey = Object.keys(suggestFor).find(
+    (key) => key !== "filename" && key !== "vscode_extension",
+  );
+  if (unknownKey) {
+    throw new Error(`${mcpId}: suggest_for has unknown property "${unknownKey}"`);
+  }
+
+  const filenames = suggestFor.filename;
+  const vscodeExtensions = suggestFor.vscode_extension;
+  if (filenames === undefined && vscodeExtensions === undefined) {
+    throw new Error(
+      `${mcpId}: suggest_for must contain filename or vscode_extension`,
+    );
+  }
+
   if (
-    !Array.isArray(extensions) ||
-    extensions.length === 0 ||
-    !extensions.every(
-      (extension) =>
-        typeof extension === "string" &&
-        /^\*\.[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)*$/.test(extension),
-    )
+    filenames !== undefined &&
+    (!Array.isArray(filenames) ||
+      filenames.length === 0 ||
+      !filenames.every(
+        (filename) =>
+          typeof filename === "string" &&
+          /^\*\.[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)*$/.test(filename),
+      ))
   ) {
     throw new Error(
-      `${mcpId}: suggest_for.extension must be a non-empty list of patterns like "*.ipynb"`,
+      `${mcpId}: suggest_for.filename must be a non-empty list of patterns like "*.ipynb"`,
+    );
+  }
+
+  if (
+    vscodeExtensions !== undefined &&
+    (!Array.isArray(vscodeExtensions) ||
+      vscodeExtensions.length === 0 ||
+      !vscodeExtensions.every(
+        (extensionId) =>
+          typeof extensionId === "string" &&
+          /^[A-Za-z0-9][A-Za-z0-9-]*\.[A-Za-z0-9][A-Za-z0-9-]*$/.test(
+            extensionId,
+          ),
+      ))
+  ) {
+    throw new Error(
+      `${mcpId}: suggest_for.vscode_extension must be a non-empty list of extension IDs like "ms-toolsai.jupyter"`,
     );
   }
 }

--- a/bin/generate-skill-marketplace.ts
+++ b/bin/generate-skill-marketplace.ts
@@ -35,18 +35,53 @@ function validateSuggestFor(value: unknown, skillId: string): unknown {
     throw new Error(`${skillId}: metadata.suggest_for must be an object`);
   }
 
-  const extensions = (value as { extension?: unknown }).extension;
+  const suggestFor = value as Record<string, unknown>;
+  const unknownKey = Object.keys(suggestFor).find(
+    (key) => key !== "filename" && key !== "vscode_extension",
+  );
+  if (unknownKey) {
+    throw new Error(
+      `${skillId}: metadata.suggest_for has unknown property "${unknownKey}"`,
+    );
+  }
+
+  const filenames = suggestFor.filename;
+  const vscodeExtensions = suggestFor.vscode_extension;
+  if (filenames === undefined && vscodeExtensions === undefined) {
+    throw new Error(
+      `${skillId}: metadata.suggest_for must contain filename or vscode_extension`,
+    );
+  }
+
   if (
-    !Array.isArray(extensions) ||
-    extensions.length === 0 ||
-    !extensions.every(
-      (extension) =>
-        typeof extension === "string" &&
-        /^\*\.[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)*$/.test(extension),
-    )
+    filenames !== undefined &&
+    (!Array.isArray(filenames) ||
+      filenames.length === 0 ||
+      !filenames.every(
+        (filename) =>
+          typeof filename === "string" &&
+          /^\*\.[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)*$/.test(filename),
+      ))
   ) {
     throw new Error(
-      `${skillId}: metadata.suggest_for.extension must be a non-empty list of patterns like "*.rb"`,
+      `${skillId}: metadata.suggest_for.filename must be a non-empty list of patterns like "*.rb"`,
+    );
+  }
+
+  if (
+    vscodeExtensions !== undefined &&
+    (!Array.isArray(vscodeExtensions) ||
+      vscodeExtensions.length === 0 ||
+      !vscodeExtensions.every(
+        (extensionId) =>
+          typeof extensionId === "string" &&
+          /^[A-Za-z0-9][A-Za-z0-9-]*\.[A-Za-z0-9][A-Za-z0-9-]*$/.test(
+            extensionId,
+          ),
+      ))
+  ) {
+    throw new Error(
+      `${skillId}: metadata.suggest_for.vscode_extension must be a non-empty list of extension IDs like "ms-toolsai.jupyter"`,
     );
   }
 

--- a/mcps/firebase/MCP.yaml
+++ b/mcps/firebase/MCP.yaml
@@ -4,7 +4,7 @@ description: The Firebase MCP server allows AI-powered development tools to work
   create and manage Firebase projects, manage Authentication users, work with data in Cloud Firestore and Data Connect,
   retrieve schemas, understand security rules, and send messages with Cloud Messaging.
 suggest_for:
-  extension:
+  filename:
     - "*.rules"
 author: firebase
 url: https://firebase.google.com/docs/cli/mcp-server

--- a/mcps/ida-pro/MCP.yaml
+++ b/mcps/ida-pro/MCP.yaml
@@ -2,7 +2,7 @@ id: ida-pro
 name: IDA Pro
 description: An MCP server for interacting with the IDA Pro disassembler.
 suggest_for:
-  extension:
+  filename:
     - "*.idb"
     - "*.i64"
 author: mrexodia

--- a/mcps/jupyter/MCP.yaml
+++ b/mcps/jupyter/MCP.yaml
@@ -2,8 +2,10 @@ id: jupyter
 name: Jupyter AI MCP
 description: Connects Kilo to JupyterLab through the built-in MCP server used by Jupyter AI, an incubating JupyterLab project. Provides tools to inspect, create, edit, and execute notebooks and cells in a running local Jupyter server.
 suggest_for:
-  extension:
+  filename:
     - "*.ipynb"
+  vscode_extension:
+    - ms-toolsai.jupyter
 author: jupyter-ai-contrib
 url: https://github.com/jupyter-ai-contrib/jupyter-server-mcp
 category: data

--- a/mcps/marketplace.yaml
+++ b/mcps/marketplace.yaml
@@ -883,7 +883,7 @@ items:
       create and manage Firebase projects, manage Authentication users, work with data in Cloud Firestore and Data
       Connect, retrieve schemas, understand security rules, and send messages with Cloud Messaging.
     suggest_for:
-      extension:
+      filename:
         - "*.rules"
     author: firebase
     url: https://firebase.google.com/docs/cli/mcp-server
@@ -1278,7 +1278,7 @@ items:
     name: IDA Pro
     description: An MCP server for interacting with the IDA Pro disassembler.
     suggest_for:
-      extension:
+      filename:
         - "*.idb"
         - "*.i64"
     author: mrexodia
@@ -1302,8 +1302,10 @@ items:
       project. Provides tools to inspect, create, edit, and execute notebooks and cells in a running local Jupyter
       server.
     suggest_for:
-      extension:
+      filename:
         - "*.ipynb"
+      vscode_extension:
+        - ms-toolsai.jupyter
     author: jupyter-ai-contrib
     url: https://github.com/jupyter-ai-contrib/jupyter-server-mcp
     category: data
@@ -1551,7 +1553,7 @@ items:
     description: Enables database operations with MotherDuck and local DuckDB, providing tools for connection
       initialization, schema reading, and query execution.
     suggest_for:
-      extension:
+      filename:
         - "*.duckdb"
     author: motherduckdb
     url: https://github.com/motherduckdb/mcp-server-motherduck

--- a/mcps/motherduck/MCP.yaml
+++ b/mcps/motherduck/MCP.yaml
@@ -3,7 +3,7 @@ name: MotherDuck
 description: Enables database operations with MotherDuck and local DuckDB, providing tools for connection
   initialization, schema reading, and query execution.
 suggest_for:
-  extension:
+  filename:
     - "*.duckdb"
 author: motherduckdb
 url: https://github.com/motherduckdb/mcp-server-motherduck

--- a/skills/angular-component/SKILL.md
+++ b/skills/angular-component/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   bindings, or implementing accessible interactive components.
 metadata:
   suggest_for:
-    extension:
+    filename:
       - "*.component.ts"
       - "*.component.html"
   category: development

--- a/skills/angular-directives/SKILL.md
+++ b/skills/angular-directives/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   directives.
 metadata:
   suggest_for:
-    extension:
+    filename:
       - "*.directive.ts"
   category: development
   source:

--- a/skills/marketplace.yaml
+++ b/skills/marketplace.yaml
@@ -111,7 +111,7 @@ items:
       accessible interactive components.
     category: development
     suggest_for:
-      extension:
+      filename:
         - "*.component.ts"
         - "*.component.html"
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/angular-component
@@ -135,7 +135,7 @@ items:
       across components. Note - use native @if/@for/@switch for control flow, not custom structural directives.
     category: development
     suggest_for:
-      extension:
+      filename:
         - "*.directive.ts"
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/angular-directives
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/angular-directives/SKILL.md


### PR DESCRIPTION
## What changed

- rename `suggest_for.extension` to `suggest_for.filename` to make its filename-glob semantics explicit
- add optional `suggest_for.vscode_extension` metadata with strict extension ID validation
- suggest the Jupyter MCP when the official `ms-toolsai.jupyter` extension is installed
- keep VS Code extension suggestions deliberately conservative; Jupyter is the only current mapping
- regenerate skill and MCP marketplace catalogs and update contributor documentation

## Validation

- regenerated `skills/marketplace.yaml`
- regenerated `mcps/marketplace.yaml`
- ran `git diff --check`
- reviewed the implementation with a focused local review agent

Local `skills-ref` validation was unavailable because `skills-ref` is not installed; the PR validation workflow covers it.
