### PR TITLE
Add jupyter-notebook skill

### DIFF
--- a/skills/jupyter-notebook/LICENSE
+++ b/skills/jupyter-notebook/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kilo-Org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/jupyter-notebook/SKILL.md
+++ b/skills/jupyter-notebook/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: jupyter-notebook
+description: Use whenever the user works with Jupyter notebooks (`.ipynb`), including creating, inspecting, editing, executing, or visualizing notebook content for experiments, explorations, or tutorials.
+metadata:
+  category: development
+  suggest_for:
+    filename:
+      - "*.ipynb"
+---
+
+
+# Jupyter Notebook Skill
+
+Create clean, reproducible Jupyter notebooks for two primary modes:
+
+- Experiments and exploratory analysis
+- Tutorials and teaching-oriented walkthroughs
+
+Prefer the bundled templates and the helper script for consistent structure and fewer JSON mistakes.
+
+## When to use
+- Create a new `.ipynb` notebook from scratch.
+- Inspect notebook cells, outputs, metadata, dependencies, or execution state.
+- Add, remove, reorder, or edit code and Markdown cells.
+- Execute notebooks, refresh saved outputs, or troubleshoot kernel failures.
+- Create or improve notebook tables, charts, and other visualizations.
+- Convert rough notes or scripts into a structured notebook.
+- Refactor an existing notebook to be more reproducible and skimmable.
+- Build experiments or tutorials that will be read or re-run by other people.
+
+## Decision tree
+- If the request is exploratory, analytical, or hypothesis-driven, choose `experiment`.
+- If the request is instructional, step-by-step, or audience-specific, choose `tutorial`.
+- If editing an existing notebook, treat it as a refactor: preserve intent and improve structure.
+
+## Choose the notebook tooling
+
+Before inspecting, editing, or executing a notebook, check whether suitable Jupyter MCP tools are available.
+
+- Prefer a connected Jupyter MCP server for notebook operations.
+- If Jupyter MCP is unavailable or an MCP operation fails, explicitly tell the user that you are switching to manual notebook editing.
+- Follow `references/manual-editing.md` before editing raw notebook JSON.
+- Do not use MCP and manual JSON editing simultaneously for the same change.
+
+## Workflow
+1. Lock the intent.
+Identify the notebook kind: `experiment` or `tutorial`.
+Capture the objective, audience, and what "done" looks like.
+
+2. Scaffold from the template.
+Use the helper script to avoid hand-authoring raw notebook JSON. Resolve `scripts/new_notebook.py` against the base directory supplied when this skill is loaded; do not assume the skill is installed under the project's `.kilo` directory.
+
+```bash
+python3 "<SKILL_BASE_DIR>/scripts/new_notebook.py" \
+  --kind experiment \
+  --title "Compare prompt variants" \
+  --out "compare-prompt-variants.ipynb"
+```
+
+```bash
+python3 "<SKILL_BASE_DIR>/scripts/new_notebook.py" \
+  --kind tutorial \
+  --title "Intro to embeddings" \
+  --out "intro-to-embeddings.ipynb"
+```
+
+3. Fill the notebook with small, runnable steps.
+Keep each code cell focused on one step.
+Add short markdown cells that explain the purpose and expected result.
+Avoid large, noisy outputs when a short summary works.
+
+4. Apply the right pattern.
+For experiments, follow `references/experiment-patterns.md`.
+For tutorials, follow `references/tutorial-patterns.md`.
+
+5. Edit safely when working with existing notebooks.
+Preserve the notebook structure; avoid reordering cells unless it improves the top-to-bottom story.
+Prefer targeted edits over full rewrites.
+If you must edit raw JSON, follow `references/manual-editing.md`.
+
+6. Validate the result.
+Run the notebook top-to-bottom when the environment allows.
+If execution is not possible, say so explicitly and call out how to validate locally.
+Use the final pass checklist in `references/quality-checklist.md`.
+
+## Templates and helper script
+- Templates live in `assets/experiment-template.ipynb` and `assets/tutorial-template.ipynb`.
+- The helper script loads a template, updates the title cell, and writes a notebook.
+
+## Temp and output conventions
+- Use the system temporary directory for intermediate files and delete them when done.
+- Save the final notebook in the user-requested location, or in the current project directory when no location is specified.
+- Use stable, descriptive filenames (for example, `ablation-temperature.ipynb`).
+
+## Dependencies (install only when needed)
+
+Optional Python packages for local notebook execution:
+
+```bash
+python3 -m pip install jupyterlab ipykernel
+```
+
+The bundled scaffold script uses only the Python standard library and does not require extra dependencies.
+
+## Environment
+No required environment variables.
+
+## Reference map
+- `references/experiment-patterns.md`: experiment structure and heuristics.
+- `references/tutorial-patterns.md`: tutorial structure and teaching flow.
+- `references/notebook-structure.md`: notebook JSON shape.
+- `references/manual-editing.md`: manual editing and execution fallback when Jupyter MCP is unavailable.
+- `references/quality-checklist.md`: final validation checklist.

--- a/skills/jupyter-notebook/SKILL.md
+++ b/skills/jupyter-notebook/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: jupyter-notebook
-description: Use whenever the user works with Jupyter notebooks (`.ipynb`), including creating, inspecting, editing, executing, or visualizing notebook content for experiments, explorations, or tutorials.
+description: >-
+  Use whenever the user works with Jupyter notebooks (`.ipynb`), including
+  creating, inspecting, editing, executing, or visualizing notebook content for
+  experiments, explorations, or tutorials.
 license: Apache-2.0
 metadata:
   category: development
   author: Kilo
   suggest_for:
     filename:
-      - "*.ipynb"
+      - '*.ipynb'
   source:
-    repository: https://github.com/Kilo-Org/skills
+    repository: 'https://github.com/Kilo-Org/skills'
     path: skills/jupyter-notebook
     license_path: LICENSE
 ---
-
 
 # Jupyter Notebook Skill
 

--- a/skills/jupyter-notebook/SKILL.md
+++ b/skills/jupyter-notebook/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: jupyter-notebook
 description: Use whenever the user works with Jupyter notebooks (`.ipynb`), including creating, inspecting, editing, executing, or visualizing notebook content for experiments, explorations, or tutorials.
+license: Apache-2.0
 metadata:
   category: development
+  author: Kilo
   suggest_for:
     filename:
       - "*.ipynb"
+  source:
+    repository: https://github.com/Kilo-Org/skills
+    path: skills/jupyter-notebook
+    license_path: LICENSE
 ---
 
 

--- a/skills/jupyter-notebook/SKILL.md
+++ b/skills/jupyter-notebook/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Use whenever the user works with Jupyter notebooks (`.ipynb`), including
   creating, inspecting, editing, executing, or visualizing notebook content for
   experiments, explorations, or tutorials.
-license: Apache-2.0
+license: MIT
 metadata:
   category: development
   author: Kilo

--- a/skills/jupyter-notebook/assets/experiment-template.ipynb
+++ b/skills/jupyter-notebook/assets/experiment-template.ipynb
@@ -1,0 +1,90 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "experiment-title",
+      "metadata": {},
+      "source": [
+        "# Experiment: TITLE\n",
+        "\n",
+        "Objective:\n",
+        "- State the question to answer.\n",
+        "- Define the success criteria.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "experiment-setup",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Setup: imports, configuration, and reproducibility\n",
+        "from __future__ import annotations\n",
+        "\n",
+        "import random\n",
+        "\n",
+        "SEED = 7\n",
+        "random.seed(SEED)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "experiment-plan",
+      "metadata": {},
+      "source": [
+        "## Plan\n",
+        "\n",
+        "- Hypothesis:\n",
+        "- Variables to change:\n",
+        "- Metrics to record:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "experiment-baseline",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Start with the smallest end-to-end baseline\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "experiment-results",
+      "metadata": {},
+      "source": [
+        "## Results\n",
+        "\n",
+        "- Key observations:\n",
+        "- Important metrics:\n",
+        "- Surprises or failure modes:\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "experiment-next",
+      "metadata": {},
+      "source": [
+        "## Next steps\n",
+        "\n",
+        "- Decision: continue, pivot, or stop.\n",
+        "- Follow-up ideas:\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/skills/jupyter-notebook/assets/tutorial-template.ipynb
+++ b/skills/jupyter-notebook/assets/tutorial-template.ipynb
@@ -1,0 +1,110 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "tutorial-title",
+      "metadata": {},
+      "source": [
+        "# Tutorial: TITLE\n",
+        "\n",
+        "Audience:\n",
+        "- Describe who this is for.\n",
+        "\n",
+        "Prerequisites:\n",
+        "- List required concepts or setup.\n",
+        "\n",
+        "Learning goals:\n",
+        "- By the end, the reader can...\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "tutorial-outline",
+      "metadata": {},
+      "source": [
+        "## Outline\n",
+        "\n",
+        "1. Setup\n",
+        "2. Minimal working example\n",
+        "3. Variations and pitfalls\n",
+        "4. Exercise\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "tutorial-setup",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Setup: keep this short and deterministic\n",
+        "from __future__ import annotations\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "tutorial-step",
+      "metadata": {},
+      "source": [
+        "## Step 1 - Start with a tiny example\n",
+        "\n",
+        "Explain what the next cell does and what result to expect.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "tutorial-example",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Minimal working example\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "tutorial-exercise",
+      "metadata": {},
+      "source": [
+        "## Exercise\n",
+        "\n",
+        "- Predict the result before running the next cell.\n",
+        "- Change one input and explain what changed.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "tutorial-answer",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise answer scaffold\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "tutorial-pitfalls",
+      "metadata": {},
+      "source": [
+        "## Pitfalls and extensions\n",
+        "\n",
+        "- Common mistake and fix:\n",
+        "- Optional extension:\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/skills/jupyter-notebook/references/experiment-patterns.md
+++ b/skills/jupyter-notebook/references/experiment-patterns.md
@@ -1,0 +1,10 @@
+# Experiment Patterns
+
+Use this structure for exploratory and experimental work:
+
+- Title and objective: state the question and the success criteria.
+- Setup and reproducibility: import only what you need, set a seed early, and keep configuration in one short cell.
+- Plan: list hypotheses, sweeps, and metrics before running code.
+- Minimal baseline: start with the smallest runnable example and confirm it runs end-to-end before adding complexity.
+- Results and notes: summarize findings in markdown near the relevant code and record key metrics in a small dictionary or table-like structure.
+- Next steps: decide whether to continue, pivot, or stop, and capture follow-up ideas as short bullets.

--- a/skills/jupyter-notebook/references/manual-editing.md
+++ b/skills/jupyter-notebook/references/manual-editing.md
@@ -1,0 +1,262 @@
+# Manual Notebook Editing And Execution
+
+Use this fallback only when no suitable Jupyter MCP connection is available or the MCP operation fails. Tell the user that manual notebook tooling is being used because MCP is unavailable.
+
+## Tool And Dependency Checks
+
+Check only what the requested operation needs. Do not install packages silently.
+
+```bash
+# Required for scaffolding and raw JSON editing
+python3 --version
+
+# Required only for local notebook execution
+command -v jupyter
+jupyter --version
+jupyter kernelspec list
+```
+
+The shell's `python3` may differ from the selected notebook kernel. For package checks, prefer the interpreter backing that kernel. Inspect kernel specifications when needed:
+
+```bash
+jupyter kernelspec list --json
+```
+
+If a requirement is missing:
+
+- Continue work that does not require it.
+- Explain which operation is blocked and which command or package is missing.
+- Ask the user to install system-level tools unless installation was explicitly requested.
+- Prefer a project virtual environment over global package installation.
+- Do not install optional packages until the requested notebook uses them.
+
+Typical macOS commands are:
+
+```bash
+brew install jupyterlab
+python3 -m pip install pandas matplotlib
+```
+
+After installation, repeat the checks and ensure the selected kernel uses the environment where packages were installed.
+
+## New Notebook Scaffolding
+
+Use the bundled standard-library helper for a new notebook. Resolve its relative path against the base directory supplied when the skill is loaded; do not assume a project-local or global installation location.
+
+```bash
+python3 "<SKILL_BASE_DIR>/scripts/new_notebook.py" \
+  --kind experiment \
+  --title "Compare housing variables" \
+  --out "housing-analysis.ipynb"
+```
+
+Use `--kind tutorial` for teaching material. The helper refuses to overwrite an existing file unless `--force` is passed. Use `--force` only when replacement was explicitly requested.
+
+Templates relative to the skill base directory are:
+
+- `assets/experiment-template.ipynb`
+- `assets/tutorial-template.ipynb`
+
+The helper uses only Python's standard library, updates the title, generates fresh cell IDs, and writes valid notebook JSON. Use templates only for new notebooks.
+
+## Local Execution
+
+To execute every code cell and save outputs into the same notebook:
+
+```bash
+jupyter nbconvert --to notebook --execute --inplace "notebook.ipynb"
+```
+
+This changes execution counts and outputs across all code cells. Use it only when the user asks to run the notebook or refresh results.
+
+After execution:
+
+- Check the command exit status.
+- Verify expected outputs and inspect saved cell errors.
+- Report relevant outputs concisely.
+- Do not claim the notebook ran if code was merely executed separately with `python3`.
+
+If `jupyter` is unavailable, identify execution as blocked and provide the appropriate installation command.
+
+## Data And Visualizations
+
+For CSV exploration:
+
+- Resolve data paths relative to the notebook's working directory.
+- Prefer already-installed packages.
+- Use `pandas` and `matplotlib` when available and appropriate.
+- Preview the data and dimensions before plotting.
+- Choose a few meaningful visuals instead of plotting every column.
+- Add short Markdown explanations around charts.
+- Use readable titles, labels, figure sizes, and restrained colors.
+- Call `plt.show()` so figures are rendered and saved during execution.
+
+Before importing a package in generated cells, verify that it is available to the selected notebook kernel, not merely to the shell's default Python.
+
+## Core Rule
+
+An `.ipynb` file is JSON. Edit the notebook data model, never a rendered approximation such as `<code_cell>` or `<markdown_cell>` tags.
+
+Some file-reading tools render notebooks as simplified cells instead of showing their literal bytes. Do not infer that the file is invalid from that rendering. Read exact on-disk content as plain text:
+
+```bash
+python3 -c 'from pathlib import Path; print(Path("notebook.ipynb").read_text(), end="")'
+```
+
+Before every edit, inspect the current on-disk JSON so concurrent user changes are not overwritten.
+
+## Limitations
+
+Raw JSON editing does not require a Jupyter server, MCP connection, or active kernel. However:
+
+- Keep the JSON syntactically valid.
+- Cell `source` is usually an array of strings with explicit newline characters.
+- Editing `outputs` changes only saved output, not kernel state.
+- Editing `kernelspec` records a preference; it does not install or start that kernel.
+- Do not edit the notebook UI and raw JSON simultaneously because one editor may overwrite the other's changes.
+- Avoid direct editing while a remote server or another user is modifying the notebook.
+
+## Notebook Structure
+
+A valid notebook has this general shape:
+
+```json
+{
+  "cells": [],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}
+```
+
+A code cell requires:
+
+```json
+{
+  "cell_type": "code",
+  "execution_count": null,
+  "id": "unique-id",
+  "metadata": {},
+  "outputs": [],
+  "source": [
+    "print(3 + 3)"
+  ]
+}
+```
+
+A Markdown cell requires:
+
+```json
+{
+  "cell_type": "markdown",
+  "id": "unique-id",
+  "metadata": {},
+  "source": [
+    "# Heading"
+  ]
+}
+```
+
+Use a unique short hexadecimal ID for a new cell, for example `secrets.token_hex(4)`. Preserve existing cell IDs.
+
+## Safe Editing Workflow
+
+1. Locate the intended notebook if the user did not provide its path.
+2. Read its literal JSON immediately before editing.
+3. Parse it with Python's standard `json` module.
+4. Modify only the requested cell or position in `data["cells"]`.
+5. Preserve every unrelated cell, output, execution count, metadata field, and unknown field.
+6. Serialize valid JSON with a trailing newline.
+7. Validate the result with `python3 -m json.tool`.
+8. If execution was requested, execute only after the edit validates.
+
+Prefer a small Python transformation over rewriting the full notebook by hand:
+
+```bash
+python3 -c '
+import json, secrets
+from pathlib import Path
+
+path = Path("notebook.ipynb")
+data = json.loads(path.read_text())
+data["cells"].insert(2, {
+    "cell_type": "code",
+    "execution_count": None,
+    "id": secrets.token_hex(4),
+    "metadata": {},
+    "outputs": [],
+    "source": ["print(\"Middle\")"]
+})
+path.write_text(json.dumps(data, indent=1, ensure_ascii=False) + "\n")
+'
+python3 -m json.tool "notebook.ipynb" >/dev/null
+```
+
+Treat references to "block 2" or "cell 2" as one-based unless context clearly indicates otherwise. Inspect neighboring cells before inserting.
+
+## Editing Existing Code
+
+When adding a line to an existing code cell:
+
+- Change only that cell's `source` array.
+- Include `\n` between source lines so they remain separate statements.
+- Keep existing saved outputs unless the user asks to clear them or requests execution.
+- Warn that saved output is stale until the cell or notebook runs.
+
+Example:
+
+```json
+"source": [
+  "print(8 + 8)\n",
+  "print(6 + 6)"
+]
+```
+
+## Preservation And Concurrency
+
+Notebook editors can save changes while the agent is working. Re-read the file immediately before transformation. Never overwrite the notebook using stale content captured earlier.
+
+Do not:
+
+- Replace notebook JSON with pseudo-XML cell tags.
+- Reconstruct all cells when a targeted JSON mutation is enough.
+- Delete saved outputs, metadata, or IDs unless requested.
+- Renumber execution counts manually.
+- Invent rendered outputs; run the notebook to generate them.
+- Use a notebook-aware rendered file view as proof of literal on-disk syntax.
+
+## Validation
+
+For an edit-only request:
+
+```bash
+python3 -m json.tool "notebook.ipynb" >/dev/null
+```
+
+For an execution request, also inspect code-cell errors:
+
+```bash
+python3 -c '
+import json
+from pathlib import Path
+
+data = json.loads(Path("notebook.ipynb").read_text())
+errors = [
+    output
+    for cell in data["cells"]
+    for output in cell.get("outputs", [])
+    if output.get("output_type") == "error"
+]
+if errors:
+    raise SystemExit("Notebook contains execution errors")
+print("Notebook executed without saved errors")
+'
+```
+
+Report what cells changed, whether JSON validation passed, whether execution occurred, and whether outputs were saved.

--- a/skills/jupyter-notebook/references/notebook-structure.md
+++ b/skills/jupyter-notebook/references/notebook-structure.md
@@ -1,0 +1,17 @@
+# Notebook Structure
+
+Jupyter notebooks are JSON documents with this high-level shape:
+
+- `nbformat` and `nbformat_minor`
+- `metadata`
+- `cells` (a list of markdown and code cells)
+
+When editing `.ipynb` files programmatically:
+
+- Preserve `nbformat` and `nbformat_minor` from the template.
+- Keep `cells` as an ordered list; do not reorder unless intentional.
+- For code cells, set `execution_count` to `null` when unknown.
+- For code cells, set `outputs` to an empty list when scaffolding.
+- For markdown cells, keep `cell_type="markdown"` and `metadata={}`.
+
+Prefer scaffolding from the bundled templates or `scripts/new_notebook.py` instead of hand-authoring raw notebook JSON.

--- a/skills/jupyter-notebook/references/quality-checklist.md
+++ b/skills/jupyter-notebook/references/quality-checklist.md
@@ -1,0 +1,11 @@
+# Quality Checklist
+
+Before delivering a notebook:
+
+- Run it top-to-bottom at least once (or as much as the environment allows).
+- Ensure early cells set all required state; avoid hidden state from prior runs.
+- Keep outputs tidy. Avoid giant outputs when a short summary works.
+- Prefer small tables, key metrics, or short printouts.
+- Keep the narrative skimmable. Use headings and short bullets, and avoid long paragraphs.
+- Leave helpful TODOs only when necessary, and label them clearly.
+- If execution is not possible, call out the risk and how to validate locally.

--- a/skills/jupyter-notebook/references/tutorial-patterns.md
+++ b/skills/jupyter-notebook/references/tutorial-patterns.md
@@ -1,0 +1,9 @@
+# Tutorial Patterns
+
+Use this structure for teaching and walkthroughs:
+
+- Audience, prerequisites, and learning goals: say who it is for, list what they should already know, and state what they will be able to do by the end.
+- Outline: provide a short numbered outline so readers can skim.
+- Step-by-step flow: pair a short markdown explanation with a small code cell that runs on its own and a brief interpretation of the result.
+- Exercises: include at least one exercise that reinforces the key concept and provide an answer scaffold in the next cell.
+- Pitfalls and extensions: call out one common mistake and how to fix it, and suggest one optional extension for curious readers.

--- a/skills/jupyter-notebook/scripts/new_notebook.py
+++ b/skills/jupyter-notebook/scripts/new_notebook.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import secrets
+from pathlib import Path
+
+
+def slugify(value):
+    slug = re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+    return slug or "notebook"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a Jupyter experiment or tutorial notebook.")
+    parser.add_argument("--kind", choices=("experiment", "tutorial"), default="experiment")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    skill_dir = Path(__file__).resolve().parents[1]
+    template = skill_dir / "assets" / f"{args.kind}-template.ipynb"
+    output = args.out or Path(f"{slugify(args.title)}.ipynb")
+
+    if output.exists() and not args.force:
+        raise SystemExit(f"Refusing to overwrite existing notebook without --force: {output}")
+
+    notebook = json.loads(template.read_text())
+    notebook["cells"][0]["source"][0] = f"# {args.kind.title()}: {args.title}\n"
+    for cell in notebook["cells"]:
+        cell["id"] = secrets.token_hex(4)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(notebook, indent=1, ensure_ascii=False) + "\n")
+    print(f"Created {output} from the {args.kind} template")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/marketplace.yaml
+++ b/skills/marketplace.yaml
@@ -281,6 +281,14 @@ items:
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/grilling
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/grilling/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/grilling.tar.gz
+  - id: jupyter-notebook
+    description: >-
+      Use whenever the user works with Jupyter notebooks (`.ipynb`), including creating, inspecting, editing, executing,
+      or visualizing notebook content for experiments, explorations, or tutorials.
+    category: development
+    githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/jupyter-notebook
+    rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/jupyter-notebook/SKILL.md
+    content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/jupyter-notebook.tar.gz
   - id: langsmith-fetch
     description: >-
       Debug LangChain and LangGraph agents by fetching execution traces from LangSmith Studio. Use when debugging agent


### PR DESCRIPTION


Adds skill for creating and editing Jupyter Notebook files - Both with and without a Jupyter MCP server available

Tested the following:
- The jupyter-notebook skill is loaded in relevant conversations
- With the MCP available it runs the MCP commands to read, overwrite, insert, and execute cells
- When the MCP is not available, the agent mentions it won't use it, and uses alternative tools, as explained in `manual-editing.md`