### PR TITLE
Preserve agent discovery tags

### DIFF
--- a/agents/architect/AGENT_DEFINITION.md
+++ b/agents/architect/AGENT_DEFINITION.md
@@ -4,6 +4,10 @@ name: Architect
 description: Stress-test technical designs and produce implementation-ready plans
 author: "@johnnyeric"
 category: development
+tags:
+  - architecture
+  - planning
+  - design
 mode: primary
 permission:
   read: allow

--- a/agents/code-reviewer/AGENT_DEFINITION.md
+++ b/agents/code-reviewer/AGENT_DEFINITION.md
@@ -4,6 +4,9 @@ name: Code Reviewer
 description: Senior software engineer conducting thorough code reviews
 author: "@olearycrew"
 category: development
+tags:
+  - review
+  - quality
 mode: primary
 permission:
   read: allow

--- a/agents/code-simplifier/AGENT_DEFINITION.md
+++ b/agents/code-simplifier/AGENT_DEFINITION.md
@@ -4,6 +4,9 @@ name: Code Simplifier
 description: For simplifying/refactoring features of codebase
 author: "@cau1k"
 category: development
+tags:
+  - refactor
+  - quality
 mode: primary
 permission:
   read: allow

--- a/agents/code-skeptic/AGENT_DEFINITION.md
+++ b/agents/code-skeptic/AGENT_DEFINITION.md
@@ -4,6 +4,9 @@ name: Code Skeptic
 description: For when you need your code criticized like nobody's business
 author: "@cau1k"
 category: development
+tags:
+  - review
+  - quality
 mode: primary
 permission:
   read: allow

--- a/agents/docs-specialist/AGENT_DEFINITION.md
+++ b/agents/docs-specialist/AGENT_DEFINITION.md
@@ -4,6 +4,9 @@ name: Documentation Specialist
 description: Focus on writing documentation, markdown files, and other text-based files
 author: "@olearycrew"
 category: development
+tags:
+  - documentation
+  - quality
 mode: primary
 permission:
   read: allow

--- a/agents/frontend-specialist/AGENT_DEFINITION.md
+++ b/agents/frontend-specialist/AGENT_DEFINITION.md
@@ -4,6 +4,11 @@ name: Frontend Specialist
 description: Frontend developer expert in React, TypeScript, and modern CSS
 author: "@olearycrew"
 category: development
+tags:
+  - frontend
+  - quality
+  - performance
+  - accessibility
 mode: primary
 permission:
   read: allow

--- a/agents/marketplace.yaml
+++ b/agents/marketplace.yaml
@@ -10,8 +10,6 @@ items:
     name: Architect
     description: Stress-test technical designs and produce implementation-ready plans
     category: development
-    tags:
-      - development
     content:
       mode: primary
       description: Stress-test technical designs and produce implementation-ready plans
@@ -122,12 +120,14 @@ items:
         question: allow
         plan_exit: allow
     author: "@johnnyeric"
+    tags:
+      - architecture
+      - planning
+      - design
   - id: code-reviewer
     name: Code Reviewer
     description: Senior software engineer conducting thorough code reviews
     category: development
-    tags:
-      - development
     content:
       mode: primary
       description: Senior software engineer conducting thorough code reviews
@@ -149,12 +149,13 @@ items:
         mcp: deny
         question: allow
     author: "@olearycrew"
+    tags:
+      - review
+      - quality
   - id: code-simplifier
     name: Code Simplifier
     description: For simplifying/refactoring features of codebase
     category: development
-    tags:
-      - development
     content:
       mode: primary
       description: For simplifying/refactoring features of codebase
@@ -241,12 +242,13 @@ items:
         mcp: allow
         question: allow
     author: "@cau1k"
+    tags:
+      - refactor
+      - quality
   - id: code-skeptic
     name: Code Skeptic
     description: For when you need your code criticized like nobody's business
     category: development
-    tags:
-      - development
     content:
       mode: primary
       description: For when you need your code criticized like nobody's business
@@ -329,12 +331,13 @@ items:
         mcp: allow
         question: allow
     author: "@cau1k"
+    tags:
+      - review
+      - quality
   - id: docs-specialist
     name: Documentation Specialist
     description: Focus on writing documentation, markdown files, and other text-based files
     category: development
-    tags:
-      - development
     content:
       mode: primary
       description: Focus on writing documentation, markdown files, and other text-based files
@@ -366,12 +369,13 @@ items:
         mcp: deny
         question: allow
     author: "@olearycrew"
+    tags:
+      - documentation
+      - quality
   - id: frontend-specialist
     name: Frontend Specialist
     description: Frontend developer expert in React, TypeScript, and modern CSS
     category: development
-    tags:
-      - development
     content:
       mode: primary
       description: Frontend developer expert in React, TypeScript, and modern CSS
@@ -400,12 +404,15 @@ items:
         mcp: deny
         question: allow
     author: "@olearycrew"
+    tags:
+      - frontend
+      - quality
+      - performance
+      - accessibility
   - id: test-engineer
     name: Test Engineer
     description: QA engineer and testing specialist
     category: development
-    tags:
-      - development
     content:
       mode: primary
       description: QA engineer and testing specialist
@@ -436,3 +443,6 @@ items:
         mcp: deny
         question: allow
     author: "@olearycrew"
+    tags:
+      - testing
+      - quality

--- a/agents/test-engineer/AGENT_DEFINITION.md
+++ b/agents/test-engineer/AGENT_DEFINITION.md
@@ -4,6 +4,9 @@ name: Test Engineer
 description: QA engineer and testing specialist
 author: "@olearycrew"
 category: development
+tags:
+  - testing
+  - quality
 mode: primary
 permission:
   read: allow

--- a/bin/generate-agents-marketplace.ts
+++ b/bin/generate-agents-marketplace.ts
@@ -26,7 +26,7 @@ const AGENT_CATEGORIES = new Set([
   "web-automation",
 ]);
 const AGENT_CONFIG_KEYS = ["model", "variant", "temperature", "top_p", "permission", "color", "steps", "hidden"];
-const MARKETPLACE_KEYS = ["author", "authorUrl", "prerequisites"];
+const MARKETPLACE_KEYS = ["author", "authorUrl", "tags", "prerequisites"];
 
 type AgentContent = {
   mode: "primary" | "subagent" | "all";
@@ -50,7 +50,7 @@ type MarketplaceAgent = {
   category: string;
   author?: string;
   authorUrl?: string;
-  tags: string[];
+  tags?: string[];
   prerequisites?: string[];
   content: AgentContent;
 };
@@ -75,9 +75,6 @@ function agentFromMarkdown(dirName: string): MarketplaceAgent {
 
   if (!AGENT_CATEGORIES.has(category)) {
     throw new Error(`${file}: invalid category "${category}"`);
-  }
-  if (frontmatter.tags !== undefined) {
-    throw new Error(`${file}: use category instead of tags`);
   }
   if (id !== dirName) {
     throw new Error(`${file}: id must match directory name (${dirName})`);
@@ -116,7 +113,6 @@ function agentFromMarkdown(dirName: string): MarketplaceAgent {
     name,
     description,
     category,
-    tags: [category],
     content: agentContent,
   };
   for (const key of MARKETPLACE_KEYS) {


### PR DESCRIPTION
## What changed

- preserve the existing agent-specific discovery tags alongside the new primary category
- stop replacing published tags with the category compatibility value
- retain the consolidated `development` category for all current agents

## Context

This follows up on #133 and addresses the Kilo Code Review warning about changing the existing `tags` API semantics.

## Validation

- `npm exec tsx generate-agents-marketplace.ts`
- `git diff --check`
