### PR TITLE
Suggest Jupyter skill for VS Code extension

### DIFF
--- a/skills/jupyter-notebook/SKILL.md
+++ b/skills/jupyter-notebook/SKILL.md
@@ -11,6 +11,8 @@ metadata:
   suggest_for:
     filename:
       - '*.ipynb'
+    vscode_extension:
+      - ms-toolsai.jupyter
   source:
     repository: 'https://github.com/Kilo-Org/skills'
     path: skills/jupyter-notebook

--- a/skills/marketplace.yaml
+++ b/skills/marketplace.yaml
@@ -293,6 +293,11 @@ items:
       Use whenever the user works with Jupyter notebooks (`.ipynb`), including creating, inspecting, editing, executing,
       or visualizing notebook content for experiments, explorations, or tutorials.
     category: development
+    suggest_for:
+      filename:
+        - "*.ipynb"
+      vscode_extension:
+        - ms-toolsai.jupyter
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/jupyter-notebook
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/jupyter-notebook/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/jupyter-notebook.tar.gz


### PR DESCRIPTION
## Summary
- add the `ms-toolsai.jupyter` VS Code extension to the Jupyter notebook skill's suggestion metadata
- regenerate the skill marketplace entry so filename and extension signals are published

Addresses the follow-up in https://github.com/Kilo-Org/kilo-marketplace/pull/134#discussion_r3465648958.

## Validation
- `./node_modules/.bin/tsx generate-skill-marketplace.ts`
- `git diff --check`