### PR TITLE
Add requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,28 @@ Examples:
 
 ---
 
+## Contributing Agents
+
+Agent definitions may declare machine-readable dependencies with an optional top-level `requirements` field in `agents/<id>/AGENT_DEFINITION.md`:
+
+```yaml
+requirements:
+  skills:
+    - jupyter-notebook
+  vscode_extensions:
+    - ms-toolsai.jupyter
+  mcps:
+    - jupyter
+```
+
+The supported subgroups are exactly `skills`, `vscode_extensions`, and `mcps`. Each subgroup that is present must be a non-empty list of non-empty strings, and every listed item is a required dependency; alternative or OR groups are not supported. Omit `requirements` entirely when the agent has no machine-readable dependencies.
+
+Skill values must be exact marketplace skill IDs, and MCP values must match the `id` in the resource's `MCP.yaml`. Both are checked during marketplace generation. VS Code extension values may be any non-empty strings. Authored values and list ordering are preserved without normalization, sorting, or deduplication.
+
+Keep setup instructions that cannot be resolved to marketplace skills, MCPs, or VS Code extensions in `prerequisites`. During generation, source `requirements` is emitted as `items[].content.requirements` so the metadata is retained in the installed agent definition.
+
+---
+
 ## Contributing MCP Servers
 
 MCP (Model Context Protocol) servers extend Kilo Code's capabilities by connecting to external tools and services.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,7 @@ metadata:
 |-------|----------|-------------|
 | `metadata.suggest_for.filename` | No | Non-empty list of patterns that make this skill highly probable from the filename alone; prefer distinctive forms such as `"*.component.ts"` and omit broad patterns such as `"*.ts"` |
 | `metadata.suggest_for.vscode_extension` | No | Non-empty list of exact VS Code extension IDs that strongly indicate this skill is relevant, such as `"ms-toolsai.jupyter"` |
+| `requirements` | No | Direct skill, VS Code extension, and MCP dependencies; see [Marketplace Requirements](#marketplace-requirements) |
 | `metadata.source.repository` | **Yes** (for contributed skills) | URL to the GitHub repository containing your skill |
 | `metadata.source.path` | **Yes** (for contributed skills) | Path within the repository to the skill directory |
 | `metadata.source.license_path` | **Yes** (for contributed skills) | Path to the LICENSE file in the source repo |
@@ -266,9 +267,9 @@ Examples:
 
 ---
 
-## Contributing Agents
+## Marketplace Requirements
 
-Agent definitions may declare machine-readable dependencies with an optional top-level `requirements` field in `agents/<id>/AGENT_DEFINITION.md`:
+Agent, skill, and MCP definitions may declare machine-readable dependencies with an optional top-level `requirements` field:
 
 ```yaml
 requirements:
@@ -280,11 +281,13 @@ requirements:
     - jupyter
 ```
 
-The supported subgroups are exactly `skills`, `vscode_extensions`, and `mcps`. Each subgroup that is present must be a non-empty list of non-empty strings, and every listed item is a required dependency; alternative or OR groups are not supported. Omit `requirements` entirely when the agent has no machine-readable dependencies.
+The supported subgroups are exactly `skills`, `vscode_extensions`, and `mcps`. Each subgroup that is present must be a non-empty list of non-empty strings, and every listed item is a direct required dependency; alternative or OR groups are not supported. Omit `requirements` entirely when the resource has no machine-readable dependencies.
 
-Skill values must be exact marketplace skill IDs, and MCP values must match the `id` in the resource's `MCP.yaml`. Both are checked during marketplace generation. VS Code extension values may be any non-empty strings. Authored values and list ordering are preserved without normalization, sorting, or deduplication.
+Skill values must be exact marketplace skill IDs, and MCP values must match the `id` in the resource's `MCP.yaml`. Both are checked during marketplace generation. A skill cannot require itself, and an MCP cannot require itself. Dependencies between multiple resources are not expanded or checked for cycles. VS Code extension values may be any non-empty strings. Authored values and list ordering are preserved without normalization, sorting, or deduplication.
 
-Keep setup instructions that cannot be resolved to marketplace skills, MCPs, or VS Code extensions in `prerequisites`. During generation, source `requirements` is emitted as `items[].content.requirements` so the metadata is retained in the installed agent definition.
+Declare requirements at the top level of `agents/<id>/AGENT_DEFINITION.md`, `skills/<id>/SKILL.md`, or `mcps/<id>/MCP.yaml`. Generated agent requirements are emitted as `items[].content.requirements` so installation retains them. Generated skill and MCP requirements remain at `items[].requirements`, because skill content is a download URL and MCP content is runtime configuration.
+
+Keep setup instructions that cannot be resolved to marketplace skills, MCPs, or VS Code extensions in `prerequisites`.
 
 ---
 
@@ -355,6 +358,7 @@ parameters:
 | `category` | Yes | Primary category: `business`, `data`, `development`, `observability`, `productivity`, `search`, or `web-automation` |
 | `suggest_for.filename` | No | Non-empty list of patterns that make this MCP server highly probable from the filename alone; prefer proprietary formats such as `"*.i64"` and omit broad patterns such as `"*.php"` |
 | `suggest_for.vscode_extension` | No | Non-empty list of exact VS Code extension IDs that strongly indicate this MCP server is relevant, such as `"ms-toolsai.jupyter"` for Jupyter |
+| `requirements` | No | Direct skill, VS Code extension, and MCP dependencies; see [Marketplace Requirements](#marketplace-requirements) |
 | `prerequisites` | No | Required software or accounts |
 | `content` | Yes | Installation configuration(s) |
 | `parameters` | No | User-configurable parameters |

--- a/agents/data/AGENT_DEFINITION.md
+++ b/agents/data/AGENT_DEFINITION.md
@@ -9,6 +9,11 @@ suggest_for:
     - "*.ipynb"
   vscode_extension:
     - ms-toolsai.jupyter
+requirements:
+  skills:
+    - data-investigation
+  vscode_extensions:
+    - ms-toolsai.jupyter
 mode: primary
 color: "#2563EB"
 prerequisites:

--- a/agents/marketplace.yaml
+++ b/agents/marketplace.yaml
@@ -368,6 +368,11 @@ items:
       options:
         displayName: Data
         id: data
+      requirements:
+        skills:
+          - data-investigation
+        vscode_extensions:
+          - ms-toolsai.jupyter
       color: "#2563EB"
     author: "@imanolmzd-svg"
     prerequisites:

--- a/bin/generate-agents-marketplace.ts
+++ b/bin/generate-agents-marketplace.ts
@@ -8,16 +8,16 @@
 import * as fs from "fs";
 import * as path from "path";
 import matter from "gray-matter";
-import * as yaml from "yaml";
 import {
   AGENT_CATEGORIES,
   buildCategorySummary,
   generateMarketplace,
   listVisibleDirectories,
+  loadMcpIds,
+  type MarketplaceRequirements,
   repoPathFromBin,
   requireString,
-  type AgentRequirements,
-  validateAgentRequirements,
+  validateRequirements,
   validateSuggestFor,
 } from "./marketplace-generator-utils.ts";
 
@@ -34,7 +34,7 @@ type AgentContent = {
   description: string;
   prompt: string;
   options: Record<string, unknown>;
-  requirements?: AgentRequirements;
+  requirements?: MarketplaceRequirements;
   model?: string;
   variant?: string;
   temperature?: number;
@@ -58,31 +58,8 @@ type MarketplaceAgent = {
   content: AgentContent;
 };
 
-function loadMcpIds(): Set<string> {
-  const sourceById = new Map<string, string>();
-
-  for (const dirName of listVisibleDirectories(mcpsDir)) {
-    const file = path.join(mcpsDir, dirName, "MCP.yaml");
-    const parsed = yaml.parse(fs.readFileSync(file, "utf-8")) as unknown;
-    const id = requireString(
-      parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>).id
-        : undefined,
-      "id",
-      file,
-    );
-    const existingFile = sourceById.get(id);
-    if (existingFile) {
-      throw new Error(`${file}: duplicate MCP id "${id}" also declared in ${existingFile}`);
-    }
-    sourceById.set(id, file);
-  }
-
-  return new Set(sourceById.keys());
-}
-
 const skillIds = new Set(listVisibleDirectories(skillsDir));
-const mcpIds = loadMcpIds();
+const mcpIds = loadMcpIds(mcpsDir);
 
 function agentFromMarkdown(dirName: string): MarketplaceAgent {
   const file = path.join(agentsDir, dirName, "AGENT_DEFINITION.md");
@@ -117,7 +94,7 @@ function agentFromMarkdown(dirName: string): MarketplaceAgent {
   if (!options || typeof options !== "object" || Array.isArray(options)) {
     throw new Error(`${file}: options must be an object`);
   }
-  const requirements = validateAgentRequirements(
+  const requirements = validateRequirements(
     frontmatter.requirements,
     id,
     skillIds,

--- a/bin/generate-agents-marketplace.ts
+++ b/bin/generate-agents-marketplace.ts
@@ -8,16 +8,22 @@
 import * as fs from "fs";
 import * as path from "path";
 import matter from "gray-matter";
+import * as yaml from "yaml";
 import {
   AGENT_CATEGORIES,
   buildCategorySummary,
   generateMarketplace,
+  listVisibleDirectories,
   repoPathFromBin,
   requireString,
+  type AgentRequirements,
+  validateAgentRequirements,
   validateSuggestFor,
 } from "./marketplace-generator-utils.ts";
 
 const agentsDir = repoPathFromBin("agents");
+const skillsDir = repoPathFromBin("skills");
+const mcpsDir = repoPathFromBin("mcps");
 
 const AGENT_MODES = new Set(["primary", "subagent", "all"]);
 const AGENT_CONFIG_KEYS = ["model", "variant", "temperature", "top_p", "permission", "color", "steps", "hidden"];
@@ -28,6 +34,7 @@ type AgentContent = {
   description: string;
   prompt: string;
   options: Record<string, unknown>;
+  requirements?: AgentRequirements;
   model?: string;
   variant?: string;
   temperature?: number;
@@ -50,6 +57,32 @@ type MarketplaceAgent = {
   prerequisites?: string[];
   content: AgentContent;
 };
+
+function loadMcpIds(): Set<string> {
+  const sourceById = new Map<string, string>();
+
+  for (const dirName of listVisibleDirectories(mcpsDir)) {
+    const file = path.join(mcpsDir, dirName, "MCP.yaml");
+    const parsed = yaml.parse(fs.readFileSync(file, "utf-8")) as unknown;
+    const id = requireString(
+      parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>).id
+        : undefined,
+      "id",
+      file,
+    );
+    const existingFile = sourceById.get(id);
+    if (existingFile) {
+      throw new Error(`${file}: duplicate MCP id "${id}" also declared in ${existingFile}`);
+    }
+    sourceById.set(id, file);
+  }
+
+  return new Set(sourceById.keys());
+}
+
+const skillIds = new Set(listVisibleDirectories(skillsDir));
+const mcpIds = loadMcpIds();
 
 function agentFromMarkdown(dirName: string): MarketplaceAgent {
   const file = path.join(agentsDir, dirName, "AGENT_DEFINITION.md");
@@ -84,6 +117,12 @@ function agentFromMarkdown(dirName: string): MarketplaceAgent {
   if (!options || typeof options !== "object" || Array.isArray(options)) {
     throw new Error(`${file}: options must be an object`);
   }
+  const requirements = validateAgentRequirements(
+    frontmatter.requirements,
+    id,
+    skillIds,
+    mcpIds,
+  );
 
   const agentContent: Record<string, unknown> = {
     mode,
@@ -95,6 +134,7 @@ function agentFromMarkdown(dirName: string): MarketplaceAgent {
       id,
     },
   };
+  if (requirements !== undefined) agentContent.requirements = requirements;
 
   for (const key of AGENT_CONFIG_KEYS) {
     if (frontmatter[key] !== undefined) agentContent[key] = frontmatter[key];

--- a/bin/generate-mcps-marketplace.ts
+++ b/bin/generate-mcps-marketplace.ts
@@ -11,12 +11,18 @@ import * as yaml from "yaml";
 import {
   buildCategorySummary,
   generateMarketplace,
+  listVisibleDirectories,
+  loadMcpIds,
   MARKETPLACE_CATEGORIES,
   repoPathFromBin,
+  validateRequirements,
   validateSuggestFor,
 } from "./marketplace-generator-utils.ts";
 
 const mcpsDir = repoPathFromBin("mcps");
+const skillsDir = repoPathFromBin("skills");
+const skillIds = new Set(listVisibleDirectories(skillsDir));
+const mcpIds = loadMcpIds(mcpsDir);
 
 generateMarketplace({
   rootDir: mcpsDir,
@@ -30,10 +36,17 @@ generateMarketplace({
     if (mcp.tags !== undefined) {
       throw new Error(`${dirName}/MCP.yaml: use category instead of tags`);
     }
-    validateSuggestFor(mcp.suggest_for, mcp.id || dirName, {
+    validateSuggestFor(mcp.suggest_for, mcp.id, {
       fieldName: "suggest_for",
       filenameExample: "*.ipynb",
     });
+    validateRequirements(
+      mcp.requirements,
+      mcp.id,
+      skillIds,
+      mcpIds,
+      { subgroup: "mcps", id: mcp.id },
+    );
 
     const marketplaceMcp = {} as typeof mcp;
     for (const [key, value] of Object.entries(mcp)) {

--- a/bin/generate-skill-marketplace.ts
+++ b/bin/generate-skill-marketplace.ts
@@ -11,11 +11,15 @@ import matter from "gray-matter";
 import {
   foldedScalar,
   generateMarketplace,
+  listVisibleDirectories,
+  loadMcpIds,
   repoPathFromBin,
+  validateRequirements,
   validateSuggestFor,
 } from "./marketplace-generator-utils.ts";
 
 const skillsDir = repoPathFromBin("skills");
+const mcpsDir = repoPathFromBin("mcps");
 
 const GITHUB_BASE_URL =
   "https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills";
@@ -24,6 +28,8 @@ const RAW_BASE_URL =
 const CONTENT_BASE_URL =
   "https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest";
 
+const skillIds = new Set(listVisibleDirectories(skillsDir));
+const mcpIds = loadMcpIds(mcpsDir);
 const declaredNames = new Set<string>();
 generateMarketplace({
   rootDir: skillsDir,
@@ -40,6 +46,13 @@ generateMarketplace({
       throw new Error(`Duplicate skill name: ${data.name}`);
     }
     declaredNames.add(data.name);
+    const requirements = validateRequirements(
+      data.requirements,
+      dirName,
+      skillIds,
+      mcpIds,
+      { subgroup: "skills", id: dirName },
+    );
     console.log(`Added: ${data.name}`);
     return {
       id: dirName,
@@ -49,6 +62,7 @@ generateMarketplace({
         fieldName: "metadata.suggest_for",
         filenameExample: "*.rb",
       }),
+      requirements,
       githubUrl: `${GITHUB_BASE_URL}/${dirName}`,
       rawUrl: `${RAW_BASE_URL}/${dirName}/SKILL.md`,
       content: `${CONTENT_BASE_URL}/${dirName}.tar.gz`,

--- a/bin/marketplace-generator-utils.ts
+++ b/bin/marketplace-generator-utils.ts
@@ -14,6 +14,12 @@ type SuggestForOptions = {
   filenameExample: string;
 };
 
+export type AgentRequirements = {
+  skills?: string[];
+  vscode_extensions?: string[];
+  mcps?: string[];
+};
+
 type GenerateMarketplaceOptions<T> = {
   rootDir: string;
   outputFile?: string;
@@ -118,6 +124,57 @@ export function foldedScalar(value: string): Scalar {
   scalar.type = Scalar.BLOCK_FOLDED;
   scalar.blockChomping = "strip";
   return scalar;
+}
+
+export function validateAgentRequirements(
+  value: unknown,
+  agentId: string,
+  skillIds: ReadonlySet<string>,
+  mcpIds: ReadonlySet<string>,
+): AgentRequirements | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${agentId}: requirements must be an object`);
+  }
+
+  const requirements = value as Record<string, unknown>;
+  const supportedSubgroups = ["skills", "vscode_extensions", "mcps"] as const;
+  const unknownKey = Object.keys(requirements).find(
+    (key) => !supportedSubgroups.includes(key as (typeof supportedSubgroups)[number]),
+  );
+  if (unknownKey) {
+    throw new Error(`${agentId}: requirements has unknown property "${unknownKey}"`);
+  }
+  if (Object.keys(requirements).length === 0) {
+    throw new Error(`${agentId}: requirements must contain at least one supported subgroup`);
+  }
+
+  for (const subgroup of supportedSubgroups) {
+    if (!Object.prototype.hasOwnProperty.call(requirements, subgroup)) continue;
+    const entries = requirements[subgroup];
+    if (
+      !Array.isArray(entries) ||
+      entries.length === 0 ||
+      !entries.every((entry) => typeof entry === "string" && entry.trim().length > 0)
+    ) {
+      throw new Error(
+        `${agentId}: requirements.${subgroup} must be a non-empty list of non-empty strings`,
+      );
+    }
+
+    const availableIds = subgroup === "skills" ? skillIds : subgroup === "mcps" ? mcpIds : undefined;
+    if (availableIds) {
+      const unknownId = entries.find((entry) => !availableIds.has(entry));
+      if (unknownId) {
+        const resource = subgroup === "skills" ? "skill" : "MCP";
+        throw new Error(
+          `${agentId}: requirements.${subgroup} references unknown ${resource} ID "${unknownId}"`,
+        );
+      }
+    }
+  }
+
+  return value as AgentRequirements;
 }
 
 export function validateSuggestFor(

--- a/bin/marketplace-generator-utils.ts
+++ b/bin/marketplace-generator-utils.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
-import { Document, Scalar } from "yaml";
+import { Document, parse, Scalar } from "yaml";
 
 const BIN_DIR = path.dirname(fileURLToPath(import.meta.url));
 
@@ -14,10 +14,15 @@ type SuggestForOptions = {
   filenameExample: string;
 };
 
-export type AgentRequirements = {
+export type MarketplaceRequirements = {
   skills?: string[];
   vscode_extensions?: string[];
   mcps?: string[];
+};
+
+type SelfRequirement = {
+  subgroup: "skills" | "mcps";
+  id: string;
 };
 
 type GenerateMarketplaceOptions<T> = {
@@ -53,6 +58,29 @@ export function listVisibleDirectories(rootDir: string): string[] {
     .readdirSync(rootDir, { withFileTypes: true })
     .filter((d) => d.isDirectory() && !d.name.startsWith("."))
     .map((dir) => dir.name);
+}
+
+export function loadMcpIds(mcpsDir: string): Set<string> {
+  const sourceById = new Map<string, string>();
+
+  for (const dirName of listVisibleDirectories(mcpsDir)) {
+    const file = path.join(mcpsDir, dirName, "MCP.yaml");
+    const parsed = parse(fs.readFileSync(file, "utf-8")) as unknown;
+    const id = requireString(
+      parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>).id
+        : undefined,
+      "id",
+      file,
+    );
+    const existingFile = sourceById.get(id);
+    if (existingFile) {
+      throw new Error(`${file}: duplicate MCP id "${id}" also declared in ${existingFile}`);
+    }
+    sourceById.set(id, file);
+  }
+
+  return new Set(sourceById.keys());
 }
 
 export function writeMarketplaceYaml(
@@ -126,15 +154,16 @@ export function foldedScalar(value: string): Scalar {
   return scalar;
 }
 
-export function validateAgentRequirements(
+export function validateRequirements(
   value: unknown,
-  agentId: string,
+  itemId: string,
   skillIds: ReadonlySet<string>,
   mcpIds: ReadonlySet<string>,
-): AgentRequirements | undefined {
+  selfRequirement?: SelfRequirement,
+): MarketplaceRequirements | undefined {
   if (value === undefined) return undefined;
   if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${agentId}: requirements must be an object`);
+    throw new Error(`${itemId}: requirements must be an object`);
   }
 
   const requirements = value as Record<string, unknown>;
@@ -143,10 +172,10 @@ export function validateAgentRequirements(
     (key) => !supportedSubgroups.includes(key as (typeof supportedSubgroups)[number]),
   );
   if (unknownKey) {
-    throw new Error(`${agentId}: requirements has unknown property "${unknownKey}"`);
+    throw new Error(`${itemId}: requirements has unknown property "${unknownKey}"`);
   }
   if (Object.keys(requirements).length === 0) {
-    throw new Error(`${agentId}: requirements must contain at least one supported subgroup`);
+    throw new Error(`${itemId}: requirements must contain at least one supported subgroup`);
   }
 
   for (const subgroup of supportedSubgroups) {
@@ -158,8 +187,15 @@ export function validateAgentRequirements(
       !entries.every((entry) => typeof entry === "string" && entry.trim().length > 0)
     ) {
       throw new Error(
-        `${agentId}: requirements.${subgroup} must be a non-empty list of non-empty strings`,
+        `${itemId}: requirements.${subgroup} must be a non-empty list of non-empty strings`,
       );
+    }
+
+    if (
+      selfRequirement?.subgroup === subgroup &&
+      entries.some((entry) => entry === selfRequirement.id)
+    ) {
+      throw new Error(`${itemId}: requirements.${subgroup} must not reference itself`);
     }
 
     const availableIds = subgroup === "skills" ? skillIds : subgroup === "mcps" ? mcpIds : undefined;
@@ -168,13 +204,13 @@ export function validateAgentRequirements(
       if (unknownId) {
         const resource = subgroup === "skills" ? "skill" : "MCP";
         throw new Error(
-          `${agentId}: requirements.${subgroup} references unknown ${resource} ID "${unknownId}"`,
+          `${itemId}: requirements.${subgroup} references unknown ${resource} ID "${unknownId}"`,
         );
       }
     }
   }
 
-  return value as AgentRequirements;
+  return value as MarketplaceRequirements;
 }
 
 export function validateSuggestFor(

--- a/skills/data-investigation/SKILL.md
+++ b/skills/data-investigation/SKILL.md
@@ -5,14 +5,13 @@ description: >-
   ad-hoc analyses. This skill should be used when investigating a business
   question, explaining a metric anomaly, validating a hypothesis, performing
   root cause analysis, or preparing a one-off investigation dashboard or memo.
-license: MIT
 metadata:
   category: data
   author: Pedro / Kilo Code
   source:
     repository: 'https://github.com/Kilo-Org/skills'
     path: skills/data-investigation
-    ref: main
+    license_path: LICENSE
     commit: a30ff33da809171784aca50d1b5978cebc2185f1
 ---
 
@@ -201,4 +200,4 @@ Every completed investigation should leave behind:
 
 ## Related Skills
 
-- Use `answering-natural-language-questions-with-dbt` when the goal is answering a business question rather than debugging why analysis or metrics disagree.
+- Use the [`answering-natural-language-questions-with-dbt`](https://github.com/dbt-labs/dbt-agent-skills/tree/main/skills/dbt/skills/answering-natural-language-questions-with-dbt) workflow when the goal is answering a business question rather than debugging why analysis or metrics disagree.

--- a/skills/data-investigation/SKILL.md
+++ b/skills/data-investigation/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: data-investigation
+description: >-
+  A workflow for conducting rigorous, reproducible data investigations and
+  ad-hoc analyses. This skill should be used when investigating a business
+  question, explaining a metric anomaly, validating a hypothesis, performing
+  root cause analysis, or preparing a one-off investigation dashboard or memo.
+license: MIT
+metadata:
+  category: data
+  author: Pedro / Kilo Code
+  source:
+    repository: 'https://github.com/Kilo-Org/skills'
+    path: skills/data-investigation
+    ref: main
+    commit: a30ff33da809171784aca50d1b5978cebc2185f1
+---
+
+# Data Investigation
+
+Use this skill to produce investigations that are fast, correct, reproducible,
+and communicate a clear conclusion rather than a pile of charts.
+
+## Purpose
+
+Every investigation should be answerable in one sentence before the first SQL
+query is written.
+
+## Phase 1: Frame Before Querying
+
+### 1. Write the one-sentence answer first
+
+Before writing any SQL, write the sentence the conclusion is expected to be.
+
+Example: `The cohort size gap is a definition problem rather than a product behavior problem.`
+
+If the sentence cannot be written, the question is not yet understood.
+
+### 2. Classify the investigation type
+
+| Type | Trigger | Approach |
+|---|---|---|
+| Gap analysis | Why do A and B not match? | Establish the gap, localize it, explain it |
+| Root cause | Why did this metric change? | Confirm real, isolate segment, align timing, validate mechanism |
+| Hypothesis test | Is X causing Y? | Define what must be true, test sub-claims, confirm or reject |
+| Feasibility check | Is this number trustworthy? | Check grain, joins, nulls, definition overlap |
+
+### 3. State 2-3 competing hypotheses before querying
+
+Never investigate with a single hypothesis. That creates confirmation bias.
+
+Order hypotheses by plausibility and note which one is currently expected to be
+correct and why.
+
+## Phase 2: Build Queries In Escalating Specificity
+
+### 1. Establish first, explain second
+
+Step 1 always confirms the anomaly is real and measures its magnitude.
+Do not jump to cause until the effect is confirmed.
+
+```sql
+select
+    <time_bucket>,
+    <source_a_count> as metric_a,
+    <source_b_count> as metric_b,
+    <source_a_count> - <source_b_count> as gap,
+    round(100.0 * (<source_a_count> - <source_b_count>) / nullif(<source_a_count>, 0), 1) as pct_gap
+from ...
+order by 1
+```
+
+### 2. Localize by breaking one dimension at a time
+
+After confirming the gap, break it down along one dimension per step:
+- By time: when did it appear?
+- By segment: who is affected?
+- By signal/source: which path is missing?
+
+### 3. Align timing with upstream changes
+
+Once the anomaly start date is known, check:
+- git commits to relevant models, ETL jobs, or application code
+- schema migrations or source changes
+- metric definition changes
+- external events such as launches, campaigns, or pricing changes
+
+A credible root cause must explain why the metric changed when it did.
+
+### 4. Validate the mechanism
+
+After identifying a candidate cause, confirm it mechanically:
+- Does the affected population match the predicted population?
+- What does the counterfactual look like?
+- Does a second independent signal support the explanation?
+
+Do not stop at correlation.
+
+### 5. Quantify each hypothesis before concluding
+
+For every candidate explanation, produce a number.
+
+Examples:
+- `H1 accounts for 1,240 users`
+- `H2 accounts for 1,050 users`
+
+If a hypothesis cannot be quantified, it is not yet validated.
+
+## Phase 3: SQL Hygiene Rules
+
+### Use stable time bounds for investigations
+
+Investigation SQL should be reproducible. Favor fixed bounds over rolling
+windows unless the analysis is intentionally operational and evergreen.
+
+```sql
+-- Prefer fixed investigation scope
+where created_at >= '2026-02-16'
+  and created_at < '2026-04-04'
+```
+
+### Add explicit grain comments in important CTEs
+
+```sql
+-- grain: one row per user
+with users as (
+    ...
+)
+```
+
+### Prefer named comparison outputs over raw aggregates
+
+Bad:
+
+```sql
+select count(*) from ...
+```
+
+Better:
+
+```sql
+select
+    count(*) as users_in_scope,
+    count(distinct org_id) as orgs_in_scope
+from ...
+```
+
+### Keep diagnostic queries small and discardable
+
+Diagnostic SQL exists to answer one question. Do not build giant reusable
+queries too early.
+
+## Phase 4: Communication Rules
+
+### Lead with the answer
+
+The first sentence of the written output should state the conclusion.
+
+Bad:
+
+`I looked at several possible explanations for the discrepancy.`
+
+Good:
+
+`The discrepancy is caused by internal users being excluded from the dashboard query but included in the warehouse baseline.`
+
+### Separate evidence from interpretation
+
+Use a structure like:
+
+1. Conclusion
+2. Evidence
+3. Why alternative hypotheses were rejected
+4. Recommended next action
+
+### Include the limiting assumption
+
+Every investigation should state the biggest assumption that could change the
+answer.
+
+Example:
+
+`This conclusion assumes backend event timestamps are complete for the affected week; if ingestion was delayed, the gap may be overstated.`
+
+## Phase 5: Output Standard
+
+Every completed investigation should leave behind:
+
+1. One-sentence answer
+2. Final supporting SQL or notebook
+3. A note on rejected hypotheses
+4. Any follow-up question or unresolved ambiguity
+
+## Common Failure Modes
+
+- Treating a metric definition dispute as a product issue
+- Comparing sources with different grain or freshness
+- Accepting the first plausible explanation without quantification
+- Writing one giant query too early
+- Ending with charts instead of an answer
+
+## Related Skills
+
+- Use `answering-natural-language-questions-with-dbt` when the goal is answering a business question rather than debugging why analysis or metrics disagree.

--- a/skills/marketplace.yaml
+++ b/skills/marketplace.yaml
@@ -447,6 +447,15 @@ items:
     githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/data-distributed-storage
     rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/data-distributed-storage/SKILL.md
     content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/data-distributed-storage.tar.gz
+  - id: data-investigation
+    description: >-
+      A workflow for conducting rigorous, reproducible data investigations and ad-hoc analyses. This skill should be
+      used when investigating a business question, explaining a metric anomaly, validating a hypothesis, performing root
+      cause analysis, or preparing a one-off investigation dashboard or memo.
+    category: data
+    githubUrl: https://github.com/Kilo-Org/kilo-marketplace/tree/main/skills/data-investigation
+    rawUrl: https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/skills/data-investigation/SKILL.md
+    content: https://github.com/Kilo-Org/kilo-marketplace/releases/download/skills-latest/data-investigation.tar.gz
   - id: data-quality-frameworks-sickn33
     description: >-
       Implement data quality validation with Great Expectations, dbt tests, and data contracts. Use when building data


### PR DESCRIPTION
Introduce a `requirements` field for agent/mcp/skill definitions that declares machine-readable dependencies on skills, VS Code extensions, and MCPs. The marketplace generator now cross-references declared agent skill and MCP IDs against their respective directories, rejecting unknown references at build time.

Add the data-investigation skill and wire it as a dependency of the Data agent alongside the ms-toolsai.jupyter extension. Document the requirements schema and authoring rules in CONTRIBUTING.md.