### PR TITLE
feat(marketplace): name extension requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,14 +276,15 @@ requirements:
   skills:
     - jupyter-notebook
   vscode_extensions:
-    - ms-toolsai.jupyter
+    - name: Jupyter
+      id: ms-toolsai.jupyter
   mcps:
     - jupyter
 ```
 
-The supported subgroups are exactly `skills`, `vscode_extensions`, and `mcps`. Each subgroup that is present must be a non-empty list of non-empty strings, and every listed item is a direct required dependency; alternative or OR groups are not supported. Omit `requirements` entirely when the resource has no machine-readable dependencies.
+The supported subgroups are exactly `skills`, `vscode_extensions`, and `mcps`. Each subgroup that is present must be a non-empty list, and every listed item is a direct required dependency; alternative or OR groups are not supported. Omit `requirements` entirely when the resource has no machine-readable dependencies.
 
-Skill values must be exact marketplace skill IDs, and MCP values must match the `id` in the resource's `MCP.yaml`. Both are checked during marketplace generation. A skill cannot require itself, and an MCP cannot require itself. Dependencies between multiple resources are not expanded or checked for cycles. VS Code extension values may be any non-empty strings. Authored values and list ordering are preserved without normalization, sorting, or deduplication.
+Skill values must be exact marketplace skill IDs, and MCP values must match the `id` in the resource's `MCP.yaml`. Both are checked during marketplace generation. A skill cannot require itself, and an MCP cannot require itself. Dependencies between multiple resources are not expanded or checked for cycles. Each VS Code extension requires a human-readable `name` and a non-empty extension identifier in `id`. Authored values and list ordering are preserved without normalization, sorting, or deduplication.
 
 Declare requirements at the top level of `agents/<id>/AGENT_DEFINITION.md`, `skills/<id>/SKILL.md`, or `mcps/<id>/MCP.yaml`. Generated agent requirements are emitted as `items[].content.requirements` so installation retains them. Generated skill and MCP requirements remain at `items[].requirements`, because skill content is a download URL and MCP content is runtime configuration.
 

--- a/agents/data/AGENT_DEFINITION.md
+++ b/agents/data/AGENT_DEFINITION.md
@@ -13,7 +13,8 @@ requirements:
   skills:
     - data-investigation
   vscode_extensions:
-    - ms-toolsai.jupyter
+    - name: Jupyter
+      id: ms-toolsai.jupyter
 mode: primary
 color: "#2563EB"
 ---

--- a/agents/marketplace.yaml
+++ b/agents/marketplace.yaml
@@ -378,7 +378,8 @@ items:
         skills:
           - data-investigation
         vscode_extensions:
-          - ms-toolsai.jupyter
+          - name: Jupyter
+            id: ms-toolsai.jupyter
       color: "#2563EB"
     author: "@imanolmzd-svg"
   - id: docs-specialist

--- a/bin/marketplace-generator-utils.ts
+++ b/bin/marketplace-generator-utils.ts
@@ -16,7 +16,7 @@ type SuggestForOptions = {
 
 export type MarketplaceRequirements = {
   skills?: string[];
-  vscode_extensions?: string[];
+  vscode_extensions?: Array<{ name: string; id: string }>;
   mcps?: string[];
 };
 
@@ -181,11 +181,31 @@ export function validateRequirements(
   for (const subgroup of supportedSubgroups) {
     if (!Object.prototype.hasOwnProperty.call(requirements, subgroup)) continue;
     const entries = requirements[subgroup];
-    if (
-      !Array.isArray(entries) ||
-      entries.length === 0 ||
-      !entries.every((entry) => typeof entry === "string" && entry.trim().length > 0)
-    ) {
+    if (!Array.isArray(entries) || entries.length === 0) {
+      throw new Error(`${itemId}: requirements.${subgroup} must be a non-empty list`);
+    }
+
+    if (subgroup === "vscode_extensions") {
+      const valid = entries.every((entry) => {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) return false;
+        const extension = entry as Record<string, unknown>;
+        return (
+          Object.keys(extension).every((key) => key === "name" || key === "id") &&
+          typeof extension.name === "string" &&
+          extension.name.trim().length > 0 &&
+          typeof extension.id === "string" &&
+          extension.id.trim().length > 0
+        );
+      });
+      if (!valid) {
+        throw new Error(
+          `${itemId}: requirements.vscode_extensions entries must contain a non-empty name and ID`,
+        );
+      }
+      continue;
+    }
+
+    if (!entries.every((entry) => typeof entry === "string" && entry.trim().length > 0)) {
       throw new Error(
         `${itemId}: requirements.${subgroup} must be a non-empty list of non-empty strings`,
       );
@@ -198,15 +218,13 @@ export function validateRequirements(
       throw new Error(`${itemId}: requirements.${subgroup} must not reference itself`);
     }
 
-    const availableIds = subgroup === "skills" ? skillIds : subgroup === "mcps" ? mcpIds : undefined;
-    if (availableIds) {
-      const unknownId = entries.find((entry) => !availableIds.has(entry));
-      if (unknownId) {
-        const resource = subgroup === "skills" ? "skill" : "MCP";
-        throw new Error(
-          `${itemId}: requirements.${subgroup} references unknown ${resource} ID "${unknownId}"`,
-        );
-      }
+    const availableIds = subgroup === "skills" ? skillIds : mcpIds;
+    const unknownId = entries.find((entry) => !availableIds.has(entry));
+    if (unknownId) {
+      const resource = subgroup === "skills" ? "skill" : "MCP";
+      throw new Error(
+        `${itemId}: requirements.${subgroup} references unknown ${resource} ID "${unknownId}"`,
+      );
     }
   }
 


### PR DESCRIPTION
Store a display name alongside each required VS Code extension ID.

This lets clients show friendly extension names while continuing to check installation by ID.