### PR TITLE
feat(skills): add pdf skill

### DIFF
--- a/skills/pdf/LICENSE
+++ b/skills/pdf/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Jie Meng
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/pdf/README.md
+++ b/skills/pdf/README.md
@@ -1,0 +1,70 @@
+# PDF Skill
+
+Read, extract, and manipulate PDF files via a bundled Python CLI script powered by [pypdf](https://pypdf.readthedocs.io/) and [pdfplumber](https://github.com/jsvine/pdfplumber).
+
+## What It Does
+
+Provides a single CLI entry point (`scripts/pdf_ops.py`) with 8 subcommands covering common PDF operations:
+
+| Category | Subcommands |
+|---|---|
+| **Inspect** | `info` |
+| **Extract** | `text`, `tables`, `extract-images` |
+| **Convert** | `to-images` |
+| **Manipulate** | `merge`, `split`, `rotate` |
+| **Security** | `decrypt` |
+
+### Scanned / Image PDFs
+
+If text extraction returns empty results, the PDF is likely a scanned document. Use `to-images` to render pages as PNG — the AI agent can then read the content visually. This approach is more reliable and lightweight than OCR.
+
+## Setup
+
+### Via mythril-agent-skills
+
+```bash
+pip install mythril-agent-skills              # text, tables, merge, split, rotate, decrypt
+pip install mythril-agent-skills[pdf-images]   # also enables to-images (PDF-to-PNG)
+```
+
+### Standalone
+
+```bash
+pip install pypdf pdfplumber      # core features
+pip install pypdfium2              # optional, for to-images
+```
+
+## Quick Examples
+
+```bash
+# Inspect a PDF
+python3 scripts/pdf_ops.py info document.pdf
+
+# Extract text from all pages
+python3 scripts/pdf_ops.py text document.pdf
+
+# Extract text from pages 1-5
+python3 scripts/pdf_ops.py text document.pdf --pages 1-5
+
+# Extract tables as markdown
+python3 scripts/pdf_ops.py tables document.pdf
+
+# Convert pages to images
+python3 scripts/pdf_ops.py to-images document.pdf --output-dir ./pages/
+
+# Merge PDFs
+python3 scripts/pdf_ops.py merge a.pdf b.pdf c.pdf -o merged.pdf
+
+# Split specific pages
+python3 scripts/pdf_ops.py split document.pdf --pages 1-5 -o first_five.pdf
+
+# Extract embedded images
+python3 scripts/pdf_ops.py extract-images document.pdf --output-dir ./images/
+```
+
+## Dependencies
+
+- Python 3.10+
+- `pypdf` >= 4.0.0 — merge, split, rotate, metadata, decrypt, extract images
+- `pdfplumber` >= 0.10.0 — text and table extraction
+- `pypdfium2` >= 4.0.0 (optional) — PDF-to-image conversion

--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: pdf
+description: >
+  Read, extract, and manipulate PDF files via a bundled Python script.
+  Supports text extraction, table extraction (to markdown/JSON/CSV),
+  metadata/info, PDF-to-image conversion, merge, split, rotate, extract
+  embedded images, and password decrypt. Trigger whenever the user asks
+  to read, inspect, extract, convert, merge, split, or manipulate a PDF
+  file, or says phrases like "read pdf", "extract text from pdf",
+  "pdf to text", "pdf tables", "pdf to image", "merge pdfs", "split pdf",
+  "pdf info", "读 pdf", "看 pdf", "看看这个 pdf", "pdf 说了什么",
+  "打开 pdf", "读一下 pdf", "提取 pdf 文字", "pdf 转图片", "合并 pdf",
+  "拆分 pdf", "pdf 表格", "pdf 内容". Also trigger when the user
+  mentions a .pdf file path and wants to inspect, read, or process it.
+license: Apache-2.0
+metadata:
+  category: document-processing
+  author: jie-meng
+  source:
+    repository: https://github.com/jie-meng/mythril-agent-skills
+    path: mythril_agent_skills/skills/pdf
+    license_path: skills/pdf/LICENSE
+---
+
+# When to Use This Skill
+
+- User mentions a `.pdf` file and wants to read, extract, or inspect its content
+- Text extraction: extract text from all or specific pages, with layout preservation
+- Table extraction: extract tables as markdown, JSON, or CSV
+- Metadata inspection: page count, title, author, creator, file size, encryption status
+- PDF to images: render pages as PNG for visual inspection (scanned/image PDFs, charts, diagrams)
+- Merge: combine multiple PDFs into one
+- Split: extract page ranges into separate files
+- Rotate: rotate specific pages
+- Extract images: extract embedded images from a PDF
+- Decrypt: remove password protection (when password is known)
+
+> **Scanned / image PDFs**: If text extraction returns empty or garbled results, the PDF is likely a scanned document. Use the `to-images` subcommand to convert pages to PNG — the AI agent can then read the content visually. This is more reliable and lightweight than OCR.
+
+# Prerequisites
+
+- `pypdf` — PDF manipulation (merge, split, rotate, metadata, decrypt, extract images)
+- `pdfplumber` — text and table extraction
+- `pypdfium2` (optional) — PDF-to-image conversion (`to-images` subcommand)
+
+Pre-flight check:
+
+```bash
+python3 -c "import pypdf; print('pypdf', pypdf.__version__)"
+python3 -c "import pdfplumber; print('pdfplumber', pdfplumber.__version__)"
+# Optional: check image conversion support
+python3 -c "import pypdfium2; print('pypdfium2', pypdfium2.__version__)"
+```
+
+Install if missing:
+
+```bash
+pip install pypdf pdfplumber
+pip install pypdfium2  # optional, for to-images
+```
+
+# Workflow
+
+1. Determine what the user wants (read text, extract tables, inspect metadata, convert to images, merge, split, etc.)
+2. Run the appropriate script subcommand
+3. Read the output (text, markdown table, JSON, or confirmation) and present it to the user
+4. For multi-step tasks, chain subcommands in sequence
+
+All commands use:
+
+```bash
+python3 scripts/pdf_ops.py <subcommand> [options] <file>
+```
+
+The script path is relative to this skill directory.
+
+# Command Reference
+
+## Inspect PDF metadata
+
+```bash
+python3 scripts/pdf_ops.py info document.pdf
+```
+
+Shows page count, title, author, subject, creator, producer, creation date, file size, and encryption status.
+
+## Extract text
+
+```bash
+# Extract text from all pages
+python3 scripts/pdf_ops.py text document.pdf
+
+# Extract text from specific pages (1-based)
+python3 scripts/pdf_ops.py text document.pdf --pages 1-5
+
+# Extract text from a single page
+python3 scripts/pdf_ops.py text document.pdf --pages 3
+
+# Combine specific pages and ranges
+python3 scripts/pdf_ops.py text document.pdf --pages 1,3,5-8
+
+# Extract with layout preservation (keeps spatial arrangement)
+python3 scripts/pdf_ops.py text document.pdf --layout
+```
+
+## Extract tables
+
+```bash
+# Extract all tables as markdown (default)
+python3 scripts/pdf_ops.py tables document.pdf
+
+# Extract tables from specific pages
+python3 scripts/pdf_ops.py tables document.pdf --pages 2-4
+
+# Extract as JSON
+python3 scripts/pdf_ops.py tables document.pdf --format json
+
+# Extract as CSV (one file per table)
+python3 scripts/pdf_ops.py tables document.pdf --format csv --output-dir ./tables/
+```
+
+## Convert PDF to images
+
+Renders each page as a PNG image. Useful for scanned PDFs, charts, diagrams, or any visual content.
+
+```bash
+# Convert all pages (output to same directory as PDF)
+python3 scripts/pdf_ops.py to-images document.pdf
+
+# Convert specific pages
+python3 scripts/pdf_ops.py to-images document.pdf --pages 1-3
+
+# Output to a specific directory
+python3 scripts/pdf_ops.py to-images document.pdf --output-dir ./pages/
+
+# Control resolution (default: 2.0x scale)
+python3 scripts/pdf_ops.py to-images document.pdf --scale 3.0
+```
+
+Output files are named `<stem>_page_1.png`, `<stem>_page_2.png`, etc.
+
+## Merge PDFs
+
+```bash
+# Merge multiple PDFs into one
+python3 scripts/pdf_ops.py merge file1.pdf file2.pdf file3.pdf -o merged.pdf
+
+# Merge all PDFs in a directory (alphabetical order)
+python3 scripts/pdf_ops.py merge *.pdf -o combined.pdf
+```
+
+## Split PDF
+
+```bash
+# Extract specific pages into a new PDF
+python3 scripts/pdf_ops.py split document.pdf --pages 1-5 -o first_five.pdf
+
+# Extract a single page
+python3 scripts/pdf_ops.py split document.pdf --pages 3 -o page3.pdf
+
+# Split into individual pages (one file per page)
+python3 scripts/pdf_ops.py split document.pdf --each --output-dir ./pages/
+```
+
+## Rotate pages
+
+```bash
+# Rotate all pages 90° clockwise
+python3 scripts/pdf_ops.py rotate document.pdf 90 -o rotated.pdf
+
+# Rotate specific pages
+python3 scripts/pdf_ops.py rotate document.pdf 90 --pages 1,3 -o rotated.pdf
+
+# Rotate counter-clockwise
+python3 scripts/pdf_ops.py rotate document.pdf 270 -o rotated.pdf
+```
+
+Valid angles: 90, 180, 270.
+
+## Extract embedded images
+
+```bash
+# Extract all images to a directory
+python3 scripts/pdf_ops.py extract-images document.pdf --output-dir ./images/
+
+# Extract from specific pages
+python3 scripts/pdf_ops.py extract-images document.pdf --pages 1-3 --output-dir ./images/
+```
+
+## Decrypt a password-protected PDF
+
+```bash
+python3 scripts/pdf_ops.py decrypt encrypted.pdf --password secret -o decrypted.pdf
+```
+
+# Composing Multi-Step Workflows
+
+The commands above are building blocks. Combine them to accomplish complex user requests. Examples:
+
+**"Read this scanned PDF":**
+1. `text` to attempt text extraction — if empty, it's a scanned document
+2. `to-images` to render pages as PNGs
+3. Read the images visually
+
+**"Extract the tables from pages 3-5 and save as CSV":**
+1. `tables --pages 3-5 --format csv --output-dir ./tables/` to extract and save
+
+**"Merge these three PDFs but only include pages 1-10 from the first one":**
+1. `split` to extract pages 1-10 from the first PDF
+2. `merge` the split output with the other two PDFs
+
+**"What's in this PDF?":**
+1. `info` to see page count, title, etc.
+2. `text --pages 1` to read the first page for a quick overview
+
+# Guidelines
+
+- **Read before manipulate**: always `info` or `text --pages 1` first to understand the document
+- **Large PDFs**: use `--pages` to limit extraction to relevant pages
+- **Empty text extraction**: if `text` returns nothing, the PDF is likely scanned/image-based — use `to-images` and read visually
+- **Output files**: `merge`, `split`, `rotate`, and `decrypt` require `-o` for the output path; they never overwrite the input file
+- **Table extraction**: not all PDFs have machine-readable tables; complex layouts may need visual inspection via `to-images`

--- a/skills/pdf/scripts/pdf_ops.py
+++ b/skills/pdf/scripts/pdf_ops.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+"""PDF file operations CLI for AI coding assistants.
+
+Provides subcommands for reading, extracting, and manipulating PDF files.
+
+Requires: pypdf (pip install pypdf), pdfplumber (pip install pdfplumber)
+Optional: pypdfium2 (pip install pypdfium2) — for PDF-to-image conversion
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from pypdf import PdfReader, PdfWriter
+except ImportError:
+    print(
+        "ERROR: pypdf is not installed.\n"
+        "Install it with: pip install pypdf",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+try:
+    import pdfplumber
+except ImportError:
+    print(
+        "ERROR: pdfplumber is not installed.\n"
+        "Install it with: pip install pdfplumber",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_page_spec(spec: str, total_pages: int) -> list[int]:
+    """Parse a page specification string into a sorted list of 0-based indices.
+
+    Accepts comma-separated values and ranges (1-based):
+      "1"       -> [0]
+      "1,3,5"   -> [0, 2, 4]
+      "1-5"     -> [0, 1, 2, 3, 4]
+      "2,5-8"   -> [1, 4, 5, 6, 7]
+    """
+    pages: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start_s, end_s = part.split("-", 1)
+            start = int(start_s)
+            end = int(end_s)
+            if start < 1 or end > total_pages or start > end:
+                print(
+                    f"ERROR: Invalid page range '{part}'. "
+                    f"Document has {total_pages} pages.",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            pages.update(range(start - 1, end))
+        else:
+            page_num = int(part)
+            if page_num < 1 or page_num > total_pages:
+                print(
+                    f"ERROR: Page {page_num} out of range. "
+                    f"Document has {total_pages} pages.",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            pages.add(page_num - 1)
+    return sorted(pages)
+
+
+def _load_reader(path: str) -> PdfReader:
+    """Load a PdfReader, handling common errors."""
+    p = Path(path)
+    if not p.exists():
+        print(f"ERROR: File not found: {path}", file=sys.stderr)
+        sys.exit(2)
+    if p.suffix.lower() != ".pdf":
+        print(f"ERROR: Not a PDF file: {path}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        return PdfReader(str(p))
+    except Exception as exc:
+        print(f"ERROR: Cannot read PDF: {exc}", file=sys.stderr)
+        sys.exit(2)
+        raise  # unreachable, satisfies type checker
+
+
+def _format_size(size_bytes: int) -> str:
+    """Format file size in human-readable form."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    if size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    return f"{size_bytes / (1024 * 1024):.1f} MB"
+
+
+def _resolve_pages(
+    args: argparse.Namespace, total_pages: int
+) -> list[int]:
+    """Resolve --pages argument to 0-based page indices, or all pages."""
+    if args.pages:
+        return _parse_page_spec(args.pages, total_pages)
+    return list(range(total_pages))
+
+
+def _write_pdf(writer: PdfWriter, output_path: str) -> None:
+    """Write a PdfWriter to disk."""
+    try:
+        with open(output_path, "wb") as f:
+            writer.write(f)
+    except Exception as exc:
+        print(f"ERROR: Failed to write PDF: {exc}", file=sys.stderr)
+        sys.exit(3)
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+def cmd_info(args: argparse.Namespace) -> None:
+    """Show PDF metadata and structure."""
+    reader = _load_reader(args.file)
+    p = Path(args.file)
+    meta = reader.metadata
+
+    print(f"# PDF Info: {p.name}\n")
+    print(f"- **Pages**: {len(reader.pages)}")
+    print(f"- **File size**: {_format_size(p.stat().st_size)}")
+    print(f"- **Encrypted**: {'Yes' if reader.is_encrypted else 'No'}")
+
+    if meta:
+        if meta.title:
+            print(f"- **Title**: {meta.title}")
+        if meta.author:
+            print(f"- **Author**: {meta.author}")
+        if meta.subject:
+            print(f"- **Subject**: {meta.subject}")
+        if meta.creator:
+            print(f"- **Creator**: {meta.creator}")
+        if meta.producer:
+            print(f"- **Producer**: {meta.producer}")
+        if meta.creation_date:
+            print(f"- **Created**: {meta.creation_date}")
+        if meta.modification_date:
+            print(f"- **Modified**: {meta.modification_date}")
+
+    for i, page in enumerate(reader.pages):
+        box = page.mediabox
+        w = float(box.width)
+        h = float(box.height)
+        w_in = w / 72
+        h_in = h / 72
+        print(
+            f"- **Page {i + 1}**: {w:.0f} x {h:.0f} pt "
+            f"({w_in:.1f} x {h_in:.1f} in)"
+        )
+
+
+def cmd_text(args: argparse.Namespace) -> None:
+    """Extract text from PDF pages."""
+    with pdfplumber.open(args.file) as pdf:
+        total = len(pdf.pages)
+        page_indices = _resolve_pages(args, total)
+
+        for idx in page_indices:
+            page = pdf.pages[idx]
+            if args.layout:
+                text = page.extract_text(
+                    layout=True, keep_blank_chars=True
+                )
+            else:
+                text = page.extract_text()
+
+            if text:
+                print(f"--- Page {idx + 1} ---")
+                print(text)
+                print()
+            else:
+                print(f"--- Page {idx + 1} ---")
+                print("(no extractable text)")
+                print()
+
+
+def cmd_tables(args: argparse.Namespace) -> None:
+    """Extract tables from PDF pages."""
+    with pdfplumber.open(args.file) as pdf:
+        total = len(pdf.pages)
+        page_indices = _resolve_pages(args, total)
+
+        all_tables: list[dict[str, Any]] = []
+        table_num = 0
+
+        for idx in page_indices:
+            page = pdf.pages[idx]
+            tables = page.extract_tables()
+            if not tables:
+                continue
+            for table_data in tables:
+                if not table_data or not any(table_data):
+                    continue
+                table_num += 1
+                all_tables.append(
+                    {
+                        "page": idx + 1,
+                        "table_number": table_num,
+                        "rows": table_data,
+                    }
+                )
+
+        if not all_tables:
+            print("No tables found in the specified pages.")
+            return
+
+        fmt = args.format
+
+        if fmt == "json":
+            print(json.dumps(all_tables, indent=2, ensure_ascii=False))
+
+        elif fmt == "csv":
+            output_dir = Path(args.output_dir) if args.output_dir else Path(".")
+            output_dir.mkdir(parents=True, exist_ok=True)
+            stem = Path(args.file).stem
+            for tbl in all_tables:
+                csv_path = (
+                    output_dir
+                    / f"{stem}_p{tbl['page']}_t{tbl['table_number']}.csv"
+                )
+                with open(csv_path, "w", newline="", encoding="utf-8") as f:
+                    writer = csv.writer(f)
+                    for row in tbl["rows"]:
+                        writer.writerow(
+                            [cell if cell is not None else "" for cell in row]
+                        )
+                print(f"Saved: {csv_path}")
+
+        else:
+            for tbl in all_tables:
+                print(
+                    f"## Table {tbl['table_number']} "
+                    f"(Page {tbl['page']})\n"
+                )
+                rows = tbl["rows"]
+                if not rows:
+                    continue
+                clean_rows = [
+                    [
+                        str(cell).replace("|", "\\|") if cell is not None else ""
+                        for cell in row
+                    ]
+                    for row in rows
+                ]
+                header = clean_rows[0]
+                print("| " + " | ".join(header) + " |")
+                print(
+                    "| " + " | ".join("---" for _ in header) + " |"
+                )
+                for row in clean_rows[1:]:
+                    while len(row) < len(header):
+                        row.append("")
+                    print("| " + " | ".join(row[: len(header)]) + " |")
+                print()
+
+
+def cmd_to_images(args: argparse.Namespace) -> None:
+    """Convert PDF pages to PNG images."""
+    try:
+        import pypdfium2 as pdfium
+    except ImportError:
+        print(
+            "ERROR: pypdfium2 is not installed.\n"
+            "Install it with: pip install pypdfium2\n"
+            "Or: pip install mythril-agent-skills[pdf-images]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    p = Path(args.file)
+    if not p.exists():
+        print(f"ERROR: File not found: {args.file}", file=sys.stderr)
+        sys.exit(2)
+
+    pdf = pdfium.PdfDocument(str(p))
+    try:
+        total = len(pdf)
+        page_indices = _resolve_pages(args, total)
+
+        output_dir = Path(args.output_dir) if args.output_dir else p.parent
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        scale = args.scale if args.scale else 2.0
+
+        for idx in page_indices:
+            page = pdf[idx]
+            bitmap = page.render(scale=scale)
+            img = bitmap.to_pil()
+
+            out_path = output_dir / f"{p.stem}_page_{idx + 1}.png"
+            img.save(str(out_path), "PNG")
+            print(f"Saved: {out_path} ({img.width}x{img.height})")
+    finally:
+        pdf.close()
+
+
+def cmd_merge(args: argparse.Namespace) -> None:
+    """Merge multiple PDFs into one."""
+    if len(args.files) < 2:
+        print("ERROR: At least 2 PDF files required for merge.", file=sys.stderr)
+        sys.exit(2)
+
+    writer = PdfWriter()
+    for pdf_path in args.files:
+        reader = _load_reader(pdf_path)
+        for page in reader.pages:
+            writer.add_page(page)
+        print(f"Added: {pdf_path} ({len(reader.pages)} pages)")
+
+    _write_pdf(writer, args.output)
+    print(f"\nMerged {len(args.files)} files -> {args.output}")
+
+
+def cmd_split(args: argparse.Namespace) -> None:
+    """Split a PDF by extracting specific pages."""
+    reader = _load_reader(args.file)
+    total = len(reader.pages)
+
+    if args.each:
+        output_dir = Path(args.output_dir) if args.output_dir else Path(".")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        stem = Path(args.file).stem
+        page_indices = _resolve_pages(args, total)
+        for idx in page_indices:
+            w = PdfWriter()
+            w.add_page(reader.pages[idx])
+            out = output_dir / f"{stem}_page_{idx + 1}.pdf"
+            _write_pdf(w, str(out))
+            print(f"Saved: {out}")
+        return
+
+    if not args.pages:
+        print(
+            "ERROR: Specify --pages or --each for split.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    if not args.output:
+        print("ERROR: -o/--output is required for split.", file=sys.stderr)
+        sys.exit(2)
+
+    page_indices = _parse_page_spec(args.pages, total)
+    writer = PdfWriter()
+    for idx in page_indices:
+        writer.add_page(reader.pages[idx])
+
+    _write_pdf(writer, args.output)
+    print(f"Split {len(page_indices)} pages -> {args.output}")
+
+
+def cmd_rotate(args: argparse.Namespace) -> None:
+    """Rotate pages in a PDF."""
+    reader = _load_reader(args.file)
+    total = len(reader.pages)
+
+    angle = args.angle
+    if angle not in (90, 180, 270):
+        print("ERROR: Angle must be 90, 180, or 270.", file=sys.stderr)
+        sys.exit(2)
+
+    if not args.output:
+        print("ERROR: -o/--output is required for rotate.", file=sys.stderr)
+        sys.exit(2)
+
+    page_indices = set(_resolve_pages(args, total))
+
+    writer = PdfWriter()
+    for i, page in enumerate(reader.pages):
+        if i in page_indices:
+            page.rotate(angle)
+        writer.add_page(page)
+
+    _write_pdf(writer, args.output)
+    rotated_desc = "all pages" if len(page_indices) == total else f"{len(page_indices)} pages"
+    print(f"Rotated {rotated_desc} by {angle}° -> {args.output}")
+
+
+def cmd_extract_images(args: argparse.Namespace) -> None:
+    """Extract embedded images from a PDF."""
+    reader = _load_reader(args.file)
+    total = len(reader.pages)
+    page_indices = _resolve_pages(args, total)
+
+    output_dir = Path(args.output_dir) if args.output_dir else Path(".")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    img_count = 0
+    stem = Path(args.file).stem
+
+    for idx in page_indices:
+        page = reader.pages[idx]
+        if "/XObject" not in page.get("/Resources", {}):
+            continue
+        x_objects = page["/Resources"]["/XObject"].get_object()
+        for obj_name in x_objects:
+            obj = x_objects[obj_name].get_object()
+            if obj.get("/Subtype") != "/Image":
+                continue
+            img_count += 1
+
+            width = obj.get("/Width", 0)
+            height = obj.get("/Height", 0)
+
+            data = obj.get_data()
+            filt = obj.get("/Filter", "")
+
+            if filt == "/DCTDecode":
+                ext = "jpg"
+            elif filt == "/JPXDecode":
+                ext = "jp2"
+            elif filt == "/FlateDecode":
+                ext = "png"
+            elif filt == "/CCITTFaxDecode":
+                ext = "tiff"
+            else:
+                ext = "bin"
+
+            out_path = output_dir / f"{stem}_p{idx + 1}_img{img_count}.{ext}"
+
+            if ext == "png":
+                try:
+                    from PIL import Image
+
+                    if "/SMask" in obj:
+                        has_alpha = True
+                    else:
+                        has_alpha = False
+
+                    cs = obj.get("/ColorSpace", "")
+                    if isinstance(cs, list):
+                        cs = str(cs[0])
+
+                    if cs in ("/DeviceRGB", "/CalRGB") or "RGB" in str(cs):
+                        mode = "RGBA" if has_alpha else "RGB"
+                        channels = 4 if has_alpha else 3
+                    elif cs in ("/DeviceGray", "/CalGray") or "Gray" in str(cs):
+                        mode = "LA" if has_alpha else "L"
+                        channels = 2 if has_alpha else 1
+                    elif cs in ("/DeviceCMYK",) or "CMYK" in str(cs):
+                        mode = "CMYK"
+                        channels = 4
+                    else:
+                        mode = "RGB"
+                        channels = 3
+
+                    expected = int(width) * int(height) * channels
+                    if len(data) >= expected:
+                        img = Image.frombytes(mode, (int(width), int(height)), data)
+                        if mode == "CMYK":
+                            img = img.convert("RGB")
+                        img.save(str(out_path), "PNG")
+                    else:
+                        out_path = out_path.with_suffix(".bin")
+                        with open(out_path, "wb") as f:
+                            f.write(data)
+                except ImportError:
+                    out_path = out_path.with_suffix(".bin")
+                    with open(out_path, "wb") as f:
+                        f.write(data)
+            else:
+                with open(out_path, "wb") as f:
+                    f.write(data)
+
+            print(
+                f"Extracted: {out_path} "
+                f"({width}x{height}, {ext})"
+            )
+
+    if img_count == 0:
+        print("No embedded images found in the specified pages.")
+    else:
+        print(f"\nExtracted {img_count} image(s).")
+
+
+def cmd_decrypt(args: argparse.Namespace) -> None:
+    """Decrypt a password-protected PDF."""
+    if not args.output:
+        print("ERROR: -o/--output is required for decrypt.", file=sys.stderr)
+        sys.exit(2)
+
+    reader = _load_reader(args.file)
+
+    if not reader.is_encrypted:
+        print("This PDF is not encrypted.")
+        return
+
+    try:
+        reader.decrypt(args.password)
+    except Exception as exc:
+        print(f"ERROR: Failed to decrypt: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    writer = PdfWriter()
+    for page in reader.pages:
+        writer.add_page(page)
+
+    _write_pdf(writer, args.output)
+    print(f"Decrypted -> {args.output}")
+
+
+# ---------------------------------------------------------------------------
+# CLI parser
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser with all subcommands."""
+    parser = argparse.ArgumentParser(
+        prog="pdf_ops.py",
+        description="PDF file operations for AI coding assistants.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # info
+    p_info = sub.add_parser("info", help="Show PDF metadata and structure")
+    p_info.add_argument("file", help="PDF file path")
+
+    # text
+    p_text = sub.add_parser("text", help="Extract text from PDF")
+    p_text.add_argument("file", help="PDF file path")
+    p_text.add_argument("--pages", help="Page spec: 1,3,5-8")
+    p_text.add_argument(
+        "--layout", action="store_true", help="Preserve spatial layout"
+    )
+
+    # tables
+    p_tables = sub.add_parser("tables", help="Extract tables from PDF")
+    p_tables.add_argument("file", help="PDF file path")
+    p_tables.add_argument("--pages", help="Page spec: 1,3,5-8")
+    p_tables.add_argument(
+        "--format",
+        choices=["markdown", "json", "csv"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    p_tables.add_argument(
+        "--output-dir", help="Output directory for CSV files"
+    )
+
+    # to-images
+    p_imgs = sub.add_parser("to-images", help="Convert PDF pages to PNG")
+    p_imgs.add_argument("file", help="PDF file path")
+    p_imgs.add_argument("--pages", help="Page spec: 1,3,5-8")
+    p_imgs.add_argument("--output-dir", help="Output directory for images")
+    p_imgs.add_argument(
+        "--scale", type=float, default=2.0, help="Render scale (default: 2.0)"
+    )
+
+    # merge
+    p_merge = sub.add_parser("merge", help="Merge multiple PDFs")
+    p_merge.add_argument("files", nargs="+", help="PDF files to merge")
+    p_merge.add_argument("-o", "--output", required=True, help="Output file")
+
+    # split
+    p_split = sub.add_parser("split", help="Split PDF by pages")
+    p_split.add_argument("file", help="PDF file path")
+    p_split.add_argument("--pages", help="Page spec: 1,3,5-8")
+    p_split.add_argument(
+        "--each",
+        action="store_true",
+        help="Split into individual page files",
+    )
+    p_split.add_argument("-o", "--output", help="Output file (for page range)")
+    p_split.add_argument(
+        "--output-dir", help="Output directory (for --each)"
+    )
+
+    # rotate
+    p_rotate = sub.add_parser("rotate", help="Rotate PDF pages")
+    p_rotate.add_argument("file", help="PDF file path")
+    p_rotate.add_argument("angle", type=int, help="Rotation angle: 90, 180, 270")
+    p_rotate.add_argument("--pages", help="Page spec: 1,3,5-8 (default: all)")
+    p_rotate.add_argument("-o", "--output", help="Output file")
+
+    # extract-images
+    p_eimg = sub.add_parser(
+        "extract-images", help="Extract embedded images from PDF"
+    )
+    p_eimg.add_argument("file", help="PDF file path")
+    p_eimg.add_argument("--pages", help="Page spec: 1,3,5-8")
+    p_eimg.add_argument("--output-dir", help="Output directory for images")
+
+    # decrypt
+    p_dec = sub.add_parser("decrypt", help="Decrypt a password-protected PDF")
+    p_dec.add_argument("file", help="PDF file path")
+    p_dec.add_argument("--password", required=True, help="PDF password")
+    p_dec.add_argument("-o", "--output", help="Output file")
+
+    return parser
+
+
+COMMAND_DISPATCH: dict[str, Any] = {
+    "info": cmd_info,
+    "text": cmd_text,
+    "tables": cmd_tables,
+    "to-images": cmd_to_images,
+    "merge": cmd_merge,
+    "split": cmd_split,
+    "rotate": cmd_rotate,
+    "extract-images": cmd_extract_images,
+    "decrypt": cmd_decrypt,
+}
+
+
+def main() -> None:
+    """Entry point."""
+    parser = build_parser()
+    args = parser.parse_args()
+    handler = COMMAND_DISPATCH.get(args.command)
+    if handler:
+        handler(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the `pdf` skill from `jie-meng/mythril-agent-skills` (Apache-2.0).

Replaces the earlier proprietary anthropics/skills approach (#163) which could not be redistributed.

Includes SKILL.md, README.md, Apache-2.0 LICENSE, and scripts/pdf_ops.py covering: info, text, tables, to-images, merge, split, rotate, extract-images, and decrypt.