### PR TITLE
Add Brain Memory MCP server

### DIFF
--- a/mcps/brain-memory/MCP.yaml
+++ b/mcps/brain-memory/MCP.yaml
@@ -1,0 +1,32 @@
+id: brain-memory
+name: Brain Memory
+description: Persistent, neuroscience-inspired memory for AI agents. Connects to the user's hosted Brain Cloud brain to
+  recall relevant memories with spreading activation and context matching, store new memories (memorize), pin
+  always-present facts, and check brain health (status) — one memory shared across Kilo, Claude Code, and other
+  coding agents.
+author: Omelas
+url: https://github.com/omelas-tech/brain
+category: data
+prerequisites:
+  - Brain Cloud account (https://brainmemory.ai)
+  - MCP client with OAuth support (for the OAuth option)
+content:
+  - name: Hosted Remote (OAuth)
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://mcp.brainmemory.ai/mcp"
+      }
+  - name: Hosted Remote (API token)
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://mcp.brainmemory.ai/mcp",
+        "headers": {
+          "Authorization": "Bearer {{BRAIN_CLOUD_TOKEN}}"
+        }
+      }
+    parameters:
+      - name: Brain Cloud Token
+        key: BRAIN_CLOUD_TOKEN
+        placeholder: your_brain_cloud_token


### PR DESCRIPTION
## What this adds

`mcps/brain-memory/MCP.yaml` — the hosted Brain Memory remote MCP server
(https://mcp.brainmemory.ai/mcp, streamable-HTTP + OAuth 2.0).

## What problem it solves

Kilo sessions start from zero: decisions, learnings, and preferences from previous
sessions — and from the user's other agents — are gone. Brain Memory gives Kilo a
persistent, cross-agent memory. The server exposes four tools against the user's
cloud-hosted brain:

- **recall** — retrieve relevant memories (deterministic scoring: relevance, decayed
  strength, spreading activation, context match, salience)
- **memorize** — store decisions, learnings, insights, and preferences from the session
- **pin** — pin/unpin a memory to the always-present tier
- **status** — brain health overview

Memories are shared across agents (Kilo, Claude Code, Copilot CLI, Codex, …), so what one
agent learns, Kilo remembers.

## Who uses this workflow

Brain Memory (https://brainmemory.ai) users — developers running the brain-memory system
(https://github.com/omelas-tech/brain) with Brain Cloud sync. The hosted MCP server is the
zero-install path: no local `brain` CLI needed, authentication via OAuth (auto-started by
Kilo on first connect) or a static bearer token.

## Authentication

OAuth 2.0 (primary option — no parameters; Kilo starts the flow automatically on connect).
A second install option accepts a static Brain Cloud API token for environments where the
OAuth browser callback is blocked.

## Testing

Verified today against Kilo CLI v7.3.54 on a fresh install: added the server via
`kilo.jsonc` (`"type": "remote"`), `kilo mcp auth brain-memory` completed the OAuth flow,
`kilo mcp list` showed the server connected, then a live session exercised all four tools
(`status`, `recall`, `memorize`, `pin`/unpin) against a real Brain Cloud account. The
`kilo.jsonc` `"type": "remote"` config matches the marketplace `streamable-http` content
block.

Note: a separate native Kilo runtime plugin exists at `integrations/kilo/` in the brain
repo (session-start injection, session tracking); this listing is only the hosted MCP
server and is independent of that plugin.
