### PR TITLE
Add Google Search Console MCP

### DIFF
--- a/mcps/mcp-gsc/MCP.yaml
+++ b/mcps/mcp-gsc/MCP.yaml
@@ -1,0 +1,15 @@
+id: mcp-gsc
+name: Google Search Console MCP
+description: Connects AI assistants to Google Search Console for organic-search analytics, URL inspection, sitemap management, indexing requests, and SEO insights.
+author: DigestSEO
+url: https://github.com/AKzar1el/mcp-gsc
+category: search
+prerequisites:
+  - Google account with access to the Search Console properties you want to use
+content:
+  - name: Hosted Streamable HTTP
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://mcp-gsc.digestseo.com/mcp"
+      }


### PR DESCRIPTION
## Summary
- Add the DigestSEO Google Search Console MCP to the official Kilo Marketplace.
- Provide the hosted Streamable HTTP configuration at `https://mcp-gsc.digestseo.com/mcp`.
- Document the Google Search Console access prerequisite.

## Validation
- Ran `pnpm install --frozen-lockfile` in `bin/`.
- Ran `pnpm exec tsx generate-mcps-marketplace.ts` successfully; the entry was included in the generated marketplace with 127 MCPs.
- Confirmed the contribution changes are limited to `mcps/mcp-gsc/MCP.yaml`.