### PR TITLE
feat: add DigestSEO GEO Tracker MCP

### DIFF
--- a/mcps/digestseo-geo/MCP.yaml
+++ b/mcps/digestseo-geo/MCP.yaml
@@ -6,7 +6,7 @@ url: https://github.com/AKzar1el/mcp-geo
 category: search
 prerequisites:
   - A DigestSEO hosted MCP connection can be authorized in the browser when using the hosted option
-  - Node.js 18 or newer and at least one supported provider API key when using the local NPX option
+  - Node.js 22 or newer and at least one supported provider API key when using the local NPX option
 content:
   - name: DigestSEO hosted MCP (OAuth)
     content: |
@@ -16,12 +16,12 @@ content:
       }
   - name: Local NPX server
     prerequisites:
-      - Node.js 18 or newer
+      - Node.js 22 or newer
       - At least one supported provider API key
     content: |
       {
         "command": "npx",
-        "args": ["-y", "digestseo-mcp"],
+        "args": ["-y", "@digestseo/mcp-geo"],
         "env": {
           "OPENAI_API_KEY": "{{OPENAI_API_KEY}}",
           "ANTHROPIC_API_KEY": "{{ANTHROPIC_API_KEY}}",

--- a/mcps/digestseo-geo/MCP.yaml
+++ b/mcps/digestseo-geo/MCP.yaml
@@ -1,0 +1,53 @@
+id: digestseo-geo
+name: DigestSEO GEO Tracker
+description: Measures how often a brand is cited and recommended across ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews, with visibility history, competitor comparisons, citation evidence, and content-gap analysis.
+author: DigestSEO
+url: https://github.com/AKzar1el/mcp-geo
+category: search
+prerequisites:
+  - A DigestSEO hosted MCP connection can be authorized in the browser when using the hosted option
+  - Node.js 18 or newer and at least one supported provider API key when using the local NPX option
+content:
+  - name: DigestSEO hosted MCP (OAuth)
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://geo-mcp.digestseo.com/mcp"
+      }
+  - name: Local NPX server
+    prerequisites:
+      - Node.js 18 or newer
+      - At least one supported provider API key
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "digestseo-mcp"],
+        "env": {
+          "OPENAI_API_KEY": "{{OPENAI_API_KEY}}",
+          "ANTHROPIC_API_KEY": "{{ANTHROPIC_API_KEY}}",
+          "GEMINI_API_KEY": "{{GEMINI_API_KEY}}",
+          "PERPLEXITY_API_KEY": "{{PERPLEXITY_API_KEY}}",
+          "SERPAPI_API_KEY": "{{SERPAPI_API_KEY}}"
+        }
+      }
+parameters:
+  - name: OpenAI API key
+    key: OPENAI_API_KEY
+    placeholder: sk-your_openai_api_key
+    optional: true
+  - name: Anthropic API key
+    key: ANTHROPIC_API_KEY
+    placeholder: sk-ant-your_anthropic_api_key
+    optional: true
+  - name: Gemini API key
+    key: GEMINI_API_KEY
+    placeholder: your_gemini_api_key
+    optional: true
+  - name: Perplexity API key
+    key: PERPLEXITY_API_KEY
+    placeholder: pplx-your_perplexity_api_key
+    optional: true
+  - name: SerpAPI API key
+    key: SERPAPI_API_KEY
+    placeholder: your_serpapi_api_key
+    optional: true


### PR DESCRIPTION
## What problem does this solve?

DigestSEO GEO Tracker lets AI assistants measure how often a brand is cited and recommended across ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews. It provides visibility history, competitor comparisons, citation evidence, and content-gap analysis for teams working on generative engine optimization.

## Who is it for?

SEO, content, and growth teams that need repeatable AI-search visibility measurements inside an MCP-compatible client.

## Installation options

- Hosted OAuth: `https://geo-mcp.digestseo.com/mcp`
- Local NPX: npx -y @digestseo/mcp-geo, using Node.js 22+ and at least one supported provider API key

The canonical source and documentation are maintained at https://github.com/AKzar1el/mcp-geo. The hosted service and product documentation are linked from the manifest.

## Example use

After connecting, ask the client to track a brand, refresh its visibility data, compare competitors, or inspect citation evidence and content gaps.

## Verification

- Confirmed the entry follows the repository's `mcps/<id>/MCP.yaml` structure.
- Confirmed the manifest uses the supported `search` category.
- Confirmed the hosted endpoint and npm package are the existing DigestSEO distribution paths.
- Confirmed the contribution contains no credentials.