### PR TITLE
Add Web Validator by DigestSEO MCP server

### DIFF
--- a/mcps/mcp-web-validator/MCP.yaml
+++ b/mcps/mcp-web-validator/MCP.yaml
@@ -1,0 +1,25 @@
+id: mcp-web-validator
+name: Web Validator by DigestSEO
+description: Validates HTML and CSS, audits technical SEO and JSON-LD, checks public links, and captures responsive screenshots for web quality workflows.
+author: DigestSEO
+url: https://github.com/AKzar1el/mcp-web-validator
+category: web-automation
+prerequisites:
+  - Internet access is required for W3C validation and eligible public-link checks.
+  - Node.js 22.12.0 or newer is required for the local NPX option.
+  - Puppeteer may download a compatible Chromium browser when screenshots are used locally.
+content:
+  - name: Local NPX server
+    prerequisites:
+      - Node.js 22.12.0 or newer
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "mcp-web-validator"]
+      }
+  - name: Hosted Streamable HTTP server
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://web-validator-mcp.digestseo.com/mcp"
+      }

--- a/mcps/mcp-web-validator/MCP.yaml
+++ b/mcps/mcp-web-validator/MCP.yaml
@@ -1,6 +1,6 @@
 id: mcp-web-validator
 name: Web Validator by DigestSEO
-description: Validates HTML and CSS, audits technical SEO and JSON-LD, checks public links, and captures responsive screenshots for web quality workflows.
+description: Provides local HTML/CSS validation, technical SEO and JSON-LD checks, broken-link checks, and responsive screenshots, plus constrained hosted public-page and site audits.
 author: DigestSEO
 url: https://github.com/AKzar1el/mcp-web-validator
 category: web-automation


### PR DESCRIPTION
## What this adds

Adds the DigestSEO Web Validator MCP to the Kilo Marketplace for real-world web quality workflows. It validates HTML and CSS, audits technical SEO and JSON-LD, checks eligible public links, and captures responsive screenshots.

## Installation options

- Local NPX stdio server: `npx -y mcp-web-validator`
- Hosted Streamable HTTP server: `https://web-validator-mcp.digestseo.com/mcp`

The local option requires Node.js 22.12.0 or newer and does not require API keys or environment variables. The hosted endpoint was verified with a successful MCP `initialize` request.

## Validation

- Kilo marketplace generator completed successfully and indexed the entry.
- YAML structure and both JSON installation payloads parsed successfully.
- `git diff --cached --check` passed.