### PR TITLE
Add DialMCP remote phone-call MCP server

### DIFF
--- a/mcps/dialmcp/MCP.yaml
+++ b/mcps/dialmcp/MCP.yaml
@@ -1,0 +1,23 @@
+id: dialmcp
+name: DialMCP
+description: Let AI agents place real phone calls from your own SMS-verified number, with full transcripts, recordings, and structured outcomes. US & Canada.
+author: DialMCP / Datawizz
+url: https://dialmcp.com
+category: communication
+prerequisites:
+  - A US or Canadian phone number you can receive SMS on
+content:
+  - name: Remote (Streamable HTTP)
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://mcp.dialmcp.com/mcp"
+      }
+  - name: NPX connector (stdio bridge)
+    prerequisites:
+      - Node.js 18+
+    content: |
+      {
+        "command": "npx",
+        "args": ["-y", "dialmcp-connector"]
+      }


### PR DESCRIPTION
## Add DialMCP

Hosted remote MCP server for placing real phone calls from the user's SMS-verified number.

| Field | Value |
|---|---|
| Endpoint | `https://mcp.dialmcp.com/mcp` |
| Transport | Streamable HTTP + OAuth 2.1 |
| Website | https://dialmcp.com |
| Connector | https://github.com/SkillfulAgents/dialmcp-connector |
| npm | `dialmcp-connector` |
| Registry | `com.dialmcp/dialmcp` |

Includes both the remote Streamable HTTP config and an optional NPX stdio bridge. Free during pilot. US & Canada only.
