### PR TITLE
Add Pocket Drives MCP server

### DIFF
--- a/mcps/pocket-drives/MCP.yaml
+++ b/mcps/pocket-drives/MCP.yaml
@@ -1,0 +1,14 @@
+id: pocket-drives
+name: Pocket Drives
+description: Search peer-to-peer luxury, exotic, and EV rentals from independent hosts via
+  a public remote MCP. No authentication required.
+author: RevList
+url: https://github.com/RevList/pocket-drives-mcp
+category: business
+content:
+  - name: Remote Streamable HTTP
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://pocketdrives.ai/mcp"
+      }


### PR DESCRIPTION
## Add Pocket Drives MCP server

Adds Pocket Drives to the `business` category.

Pocket Drives is a peer-to-peer luxury, exotic, and EV rental marketplace of independent hosts. The public MCP is remote Streamable HTTP with no authentication.

### Details

- `mcps/pocket-drives/MCP.yaml`: remote `streamable-http` server at `https://pocketdrives.ai/mcp` (no auth, no headers).
- `url` is pinned to the canonical GitHub repo `https://github.com/RevList/pocket-drives-mcp` as required by CONTRIBUTING.md.
- `mcps/marketplace.yaml` is generated; not edited. CI can re-run `bin/generate-mcps-marketplace.ts`.

### Verification

- Confirmed Pocket Drives was not already listed (`mcps/pocket-drives` absent; no name match in code/issues/PRs).
- `MCP.yaml` matches the remote streamable-http schema used by `neon` and `membrane-cloud-mcp`.
- Embedded server config is valid JSON. No credentials. Bookings happen in the iOS app; the MCP is search/browse.

Homepage: https://pocketdrives.ai  
Tools: https://pocketdrives.ai/mcp/tools  
Repo: https://github.com/RevList/pocket-drives-mcp