### PR TITLE
Add TrendPulse Google News & Trends MCP

### DIFF
--- a/mcps/mcp-trendpulse/MCP.yaml
+++ b/mcps/mcp-trendpulse/MCP.yaml
@@ -1,0 +1,23 @@
+id: mcp-trendpulse
+name: TrendPulse - Google News & Trends
+description: Researches current Google News and Google Trends data, including articles, trending terms, interest over time, growth, regions, related queries, and topics.
+author: Tomi Šeregi
+url: https://github.com/AKzar1el/mcp-trendpulse
+category: search
+prerequisites:
+  - uv/uvx is required to run the current GitHub-distributed package.
+  - Internet access is required for Google News, Google Trends, and article retrieval.
+  - Playwright Chromium is optional and only needed for browser fallback on difficult article pages.
+content:
+  - name: UVX from GitHub
+    prerequisites:
+      - uv/uvx
+    content: |
+      {
+        "command": "uvx",
+        "args": [
+          "--from",
+          "git+https://github.com/AKzar1el/mcp-trendpulse.git",
+          "mcp-trendpulse"
+        ]
+      }

--- a/mcps/mcp-trendpulse/MCP.yaml
+++ b/mcps/mcp-trendpulse/MCP.yaml
@@ -5,19 +5,15 @@ author: Tomi Šeregi
 url: https://github.com/AKzar1el/mcp-trendpulse
 category: search
 prerequisites:
-  - uv/uvx is required to run the current GitHub-distributed package.
+  - Python with uv/uvx is required to run the published package.
   - Internet access is required for Google News, Google Trends, and article retrieval.
   - Playwright Chromium is optional and only needed for browser fallback on difficult article pages.
 content:
-  - name: UVX from GitHub
+  - name: UVX (PyPI 0.2.11)
     prerequisites:
       - uv/uvx
     content: |
       {
         "command": "uvx",
-        "args": [
-          "--from",
-          "git+https://github.com/AKzar1el/mcp-trendpulse.git",
-          "mcp-trendpulse"
-        ]
+        "args": ["mcp-trendpulse==0.2.11"]
       }


### PR DESCRIPTION
## What problem does this solve?

TrendPulse gives Kilo users an MCP-native way to research current Google News and Google Trends data while working in an agent session. It supports news discovery and article extraction plus trending terms, interest over time, growth comparisons, regional interest, related queries, and related topics.

## Who is it for?

Developers, SEO/content teams, researchers, and growth teams that need current news or search-interest context without leaving Kilo.

## Installation

- UVX from PyPI: `uvx mcp-trendpulse==0.2.13`
- Source: https://github.com/AKzar1el/mcp-trendpulse
- Engineering context: https://tomiseregi.si/projects/digestseo-mcp-suite

The package is published on PyPI; the marketplace manifest now pins the patched stable `mcp-trendpulse==0.2.13` release for the local Community stdio server. The unreleased hosted TrendPulse surface is not advertised in this submission.

## Example use

Ask Kilo to find current news about a topic, compare search-interest momentum between keywords, inspect related queries/topics, or retrieve geographic interest while implementing or researching a market-facing feature.

## Validation

- Contribution is limited to `mcps/mcp-trendpulse/MCP.yaml`.
- `search` is a supported Kilo MCP category.
- The YAML structure and embedded MCP JSON configuration parse successfully.
- The manifest uses the repository's documented current `uvx` installation path and contains no credentials.