### PR TITLE
Add BestPrice Shopping MCP

### DIFF
--- a/mcps/bestprice-shopping/MCP.yaml
+++ b/mcps/bestprice-shopping/MCP.yaml
@@ -1,0 +1,15 @@
+id: bestprice-shopping
+name: BestPrice Shopping
+description: Searches Greek products, compares merchant offers, and retrieves price history through BestPrice's public, read-only hosted MCP server.
+author: BestPrice.gr
+url: https://github.com/TheBestCo/bestprice-mcp
+category: search
+prerequisites:
+  - No account or API key required
+content:
+  - name: BestPrice hosted remote server
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://mcp.bestprice.gr/mcp"
+      }


### PR DESCRIPTION
## Add BestPrice Shopping MCP

Adds BestPrice's public hosted Streamable HTTP MCP server.

- Endpoint: https://mcp.bestprice.gr/mcp
- Source: https://github.com/TheBestCo/bestprice-mcp
- No account or API key required
- Read-only product search, offer comparison, price history, and shopping-decision guidance for Greece

The listing uses Kilo's remote MCP configuration. Its workflow can regenerate `mcps/marketplace.yaml` automatically.