### PR TITLE
Add CentricMem Agent skill

### DIFF
--- a/skills/centricmem-agent/REFERENCE.md
+++ b/skills/centricmem-agent/REFERENCE.md
@@ -12,11 +12,11 @@ Library  (one per person — login, billing, delete)
               Original (optional) — pointer in Details; bytes in object storage
 ```
 
-Inbox is a system shelf (`unclassified`), never a sweep target. Tags are about the work. `project:` / `type:` / `#id` in search are index shortcuts, not extra types. Corpus YAML is that shelf’s Details.
+Inbox is gone. Do not mint `unclassified`. Leftover Inbox on an old hub: `cm_copy` `{from:unclassified,to:<named>}` then `cm_delete` `{id:unclassified}`. Never copy **to** Inbox. Tags are about the work. `project:` / `type:` / `#id` in search are index shortcuts, not extra types. Corpus YAML is that shelf’s Details.
 
 ## Reach
 
-MCP tools must be present: `cm_health` `cm_ambient` `cm_doctor` `cm_search` `cm_show` `cm_note` `cm_log_decision` `cm_done` `cm_keep` `cm_library` `cm_inbox` `cm_import` `cm_classify` `cm_index`.
+MCP tools must be present: `cm_health` `cm_ambient` `cm_doctor` `cm_search` `cm_show` `cm_note` `cm_log_decision` `cm_done` `cm_keep` `cm_library` `cm_copy` `cm_delete` `cm_import` `cm_index`.
 
 If they are missing, send the authenticate link. Run `centricmem connect --device` and send **only** the printed `/connect?device=` URL — never the secret, never the key. They have ten minutes. They enter **any** agent key on that page (default = every shelf, extra key = granted shelves) — never in chat. Humans sign in at the website for the dashboard. Do not send a loopback `/connect`. Do not curl. Do not CLI-write. Do not bootstrap.
 
@@ -52,9 +52,9 @@ Sandbox fallback (only if `cm_health` has no `mcp` field, or the origin is not u
 }
 ```
 
-`setup --install-skill` on a machine that already has the client can merge this into each agent’s MCP config (cloud URL when `/health` advertises `mcp`, otherwise stdio). When a key is needed, the agent runs `centricmem connect --device` and sends **only** the printed `/connect?device=` URL (ten minutes; secret stays on the agent). The human enters **any** agent key on that page: default (`*` = every shelf) or an extra key (granted shelves). Never ask them to paste a token in chat. Never one-click install. Never a dashboard “connect this computer”. Token failure: say once; send a new device link.
+`setup --install-skill` on a guest copies Skill files only (CLI >=0.21.25). It must not merge leftover catalog pairing tokens into Cursor `mcp.json`. Host MCP on a guest is `centricmem connect --device` (cloud `/mcp` Bearer). Local librarian hosts may still merge loopback MCP when `/health` advertises `mcp`. When a key is needed, the agent runs `centricmem connect --device` and sends **only** the printed `/connect?device=` URL (ten minutes; secret stays on the agent). The human enters **any** agent key on that page: default (`*` = every shelf) or an extra key (granted shelves). Never ask them to paste a token in chat. Never one-click install. Never a dashboard “connect this computer”. Token failure: say once; send a new device link; **hold the sweep** (this agent’s memory `CentricMem deferred sweep` + transcript path) until `cm_health` works. Only drop the hold if they said don't log or they stopped using this Skill.
 
-Do **not** call `/download`, `/delete`, billing, or `/register` `/login`. Humans download originals and delete on the dashboard. Login uniquely owns delete and billing. The **default** key (`*`) may mint, rename, grant, and revoke extras — that stays HTTP/dashboard/CLI, not these `cm_*` tools, so a new token never lands in chat. Extra keys cannot manage keys. Attachments are metered per plan (Lite 100MB, Education 200MB, Pro 1GB, Ultra 10GB; operator uncapped). Over quota, `cm_keep` fails — say so; do not drop bytes silently.
+Do **not** call `/download`, HTTP `/delete` (cards), billing, or `/register` `/login`. Humans download originals and **delete cards** on the dashboard. Login uniquely owns **card** delete and billing. The **default** key (`*`) may mint, rename, grant, and revoke extras — that stays HTTP/dashboard/CLI, not these `cm_*` tools, so a new token never lands in chat. Default (and owner login) may `cm_copy` / `cm_delete` leftover shelves (`cm_delete` is delete, not archive — no restore). Extra keys cannot manage keys or delete a leftover shelf; they may `cm_copy` if both grants. Attachments are metered per plan (Lite 100MB, Education 200MB, Pro 1GB, Ultra 10GB; operator uncapped). Over quota, `cm_keep` fails — say so; do not drop bytes silently.
 
 ## Search and show
 
@@ -76,8 +76,9 @@ Useful query bits (in `q` / `tags` / `type`): `filter`, `tag`, `type:decision`, 
 | Why we chose X | `cm_search` (decision) |
 | What we know | `cm_search` + lessons / `tags` |
 | Human wants the file | tell them Dashboard Download Original |
-| Durable work just finished | pick a **named** shelf (or `cm_library`), then one MCP sweep **this turn** — never Inbox |
-| Inbox leftover | `cm_inbox`; `apply` high-confidence; `cm_classify` the rest (default may `cm_library`) — do not leave for the human |
+| Durable work just finished | pick a **named** shelf (or `cm_library`), then one MCP sweep **this turn** |
+| Librarian down / token failed | compose the sweep anyway; this agent’s memory `CentricMem deferred sweep`; connect link once; file the hold when health succeeds |
+| Leftover named shelf or leftover Inbox | dest must exist; `cm_copy` `{from,to}` on the librarian, then `cm_delete` `{id}`. Never download originals here. Never `to=unclassified` |
 | Structured corpus (`corpus=slug`) | `library=` that slug; `cm_search` then `cm_show` the **card**, not a dump page |
 
 Empty ambient + Work/Ops → do not deep-search; execute, then sweep this turn.
@@ -88,7 +89,7 @@ Guests install from GitHub, not from the librarian disk. `cm_health` `min_skill`
 
 1. Read `version` from this Skill’s frontmatter (`metadata.version`).
 2. `latest` = JSON `skill_latest` if present, else `metadata.version` at `https://raw.githubusercontent.com/zeyu-j/centricmem-skill/main/skills/centricmem-agent/SKILL.md`.
-3. If `latest` is newer: `npx --yes skills add zeyu-j/centricmem-skill --skill centricmem-agent -g -y`. Say once: on disk now; this chat still uses the loaded copy.
+3. If `latest` is newer: `npx --yes skills add zeyu-j/centricmem-skill --skill centricmem-agent -g -y` (portable SKILL.md for Cursor, Claude, Codex, Kiro, Kilo, Copilot, skills.sh, SkillKit). If this session is a **plugin** install, also update via that client (`/plugin`, Codex plugins UI, Copilot plugin, Kiro Powers re-import). Say once: on disk now; this chat still uses the loaded copy.
 4. If this file is newer, or the fetch/npx fails: continue. Do not `setup --install-skill`.
 
 ## Writes (one sweep as soon as Non-Micro work exists)
@@ -101,10 +102,12 @@ Hold half-finished thoughts. When the chunk is done, file **before you stop talk
 | Session | Same sweep | `cm_done` with `attach` |
 | Knowledge | durable model / fact | `cm_note` |
 | Decision | architecture or durable host fact | `cm_log_decision` |
-| Original | a file worth keeping | `cm_keep` as above. Never `path=`. Never Inbox |
+| Original | a file worth keeping | `cm_keep` as above. Never `path=` |
 | Shelf | none of the named shelves fit | `cm_library` `{id}` (default key). Extra: authenticate so they enter the **default** key. Connect does not mint a shelf |
-| Bundle | capture import | `cm_import` with `library=` |
-| Inbox leftover | drain into a named shelf | `cm_classify` |
+| Shelf label | human wants a different display name | they rename on the Library desk; or default key `cm_library` `{id, displayName}` (id stays) |
+| Copy shelf | leftover named shelf (or leftover Inbox) should live on another | `cm_copy` `{from,to}`. Dest must exist. Extra keys need both grants. Never download originals here. Never `to=unclassified` |
+| Delete leftover shelf | leftover is empty or already copied | `cm_delete` `{id}` (default key or login). Extra keys cannot. Leftover Inbox may be the source. This is delete, not archive |
+| Bundle | capture import | `cm_import` with `library=` a named shelf |
 | Index | after bulk import | `cm_index` |
 
 Later sweeps in the same chat are OK for **new** facts. Do not re-file the same decision.
@@ -113,15 +116,16 @@ Do not send `path=` for the librarian to open a server file. Mention `#NNNN` in 
 
 Cursor already writes `~/.cursor/projects/<workspace>/agent-transcripts/<uuid>/<uuid>.jsonl`. Shell-read it; never paste jsonl; never delete that local file.
 
-Other agents: only keep a transcript if that runtime actually writes a local file. If there is no file, say so; do not invent a dump.
+Claude Code, Codex, Kiro, Kilo, Copilot, and other Agent Skills clients: only keep a transcript if that runtime actually wrote a local file for **this** chat. If there is no file, say so; do not invent a dump. Never paste the bytes into chat.
 
 ## Do not
 
 - Curl librarian HTTP (or CLI `note` / `keep` / `done`) when MCP is the Skill path
 - Wait for 收尾 / close / wrap up / "log this" before filing finished Non-Micro work
 - `setup --bootstrap` on a guest machine
-- Uninstall Cursor memories or write back into them
+- Uninstall the agent’s own memories or write back into them
 - Put secrets in cards
+- Ask the human to paste a key, token, or transcript jsonl. If they leaked a key, they sign in and rotate it on Keys.
 - Load attach originals into the chat
 - Treat this git checkout as the memory disk
-- Write Inbox / `unclassified` — pick or create a named shelf
+- Write `unclassified` — pick or create a named shelf. Writes without one are 400 `LIBRARY_REQUIRED`.

--- a/skills/centricmem-agent/REFERENCE.md
+++ b/skills/centricmem-agent/REFERENCE.md
@@ -1,0 +1,127 @@
+# CentricMem Agent — how to use
+
+The session loop lives in [SKILL.md](SKILL.md). Agents talk to the hosted librarian **only through host MCP**. Prefer the cloud URL `https://mem.centricmem.com/mcp` (Bearer: the default key, or an extra key with shelf grants). stdio `centricmem-host` is the sandbox fallback when `/health` has no `mcp` field. You do not curl librarian HTTP.
+
+## What you are filing
+
+```text
+Library  (one per person — login, billing, delete)
+  └── Shelf  (pass shelf=<id> or library=<id>)
+        └── Card  (.md or one ##)
+              Identity / Details / Tags / Body
+              Original (optional) — pointer in Details; bytes in object storage
+```
+
+Inbox is a system shelf (`unclassified`), never a sweep target. Tags are about the work. `project:` / `type:` / `#id` in search are index shortcuts, not extra types. Corpus YAML is that shelf’s Details.
+
+## Reach
+
+MCP tools must be present: `cm_health` `cm_ambient` `cm_doctor` `cm_search` `cm_show` `cm_note` `cm_log_decision` `cm_done` `cm_keep` `cm_library` `cm_inbox` `cm_import` `cm_classify` `cm_index`.
+
+If they are missing, send the authenticate link. Run `centricmem connect --device` and send **only** the printed `/connect?device=` URL — never the secret, never the key. They have ten minutes. They enter **any** agent key on that page (default = every shelf, extra key = granted shelves) — never in chat. Humans sign in at the website for the dashboard. Do not send a loopback `/connect`. Do not curl. Do not CLI-write. Do not bootstrap.
+
+Config (agent key stays off git):
+
+```json
+{
+  "mcpServers": {
+    "centricmem": {
+      "type": "http",
+      "url": "https://mem.centricmem.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <default key or extra key>"
+      }
+    }
+  }
+}
+```
+
+Sandbox fallback (only if `cm_health` has no `mcp` field, or the origin is not upgraded yet):
+
+```json
+{
+  "mcpServers": {
+    "centricmem": {
+      "command": "centricmem-host",
+      "env": {
+        "CENTRICMEM_URL": "https://mem.centricmem.com",
+        "CENTRICMEM_TOKEN": "<default key or extra key>"
+      }
+    }
+  }
+}
+```
+
+`setup --install-skill` on a machine that already has the client can merge this into each agent’s MCP config (cloud URL when `/health` advertises `mcp`, otherwise stdio). When a key is needed, the agent runs `centricmem connect --device` and sends **only** the printed `/connect?device=` URL (ten minutes; secret stays on the agent). The human enters **any** agent key on that page: default (`*` = every shelf) or an extra key (granted shelves). Never ask them to paste a token in chat. Never one-click install. Never a dashboard “connect this computer”. Token failure: say once; send a new device link.
+
+Do **not** call `/download`, `/delete`, billing, or `/register` `/login`. Humans download originals and delete on the dashboard. Login uniquely owns delete and billing. The **default** key (`*`) may mint, rename, grant, and revoke extras — that stays HTTP/dashboard/CLI, not these `cm_*` tools, so a new token never lands in chat. Extra keys cannot manage keys. Attachments are metered per plan (Lite 100MB, Education 200MB, Pro 1GB, Ultra 10GB; operator uncapped). Over quota, `cm_keep` fails — say so; do not drop bytes silently.
+
+## Search and show
+
+Progressive disclosure:
+
+| Layer | Call | What you get |
+|-------|------|----------------|
+| L0 | `cm_search` | snippet from the Markdown **card** |
+| L1 | `cm_show` | the card — agent context |
+| Original | human Dashboard **Download Original** | attach bytes. Not FTS. Not agent context |
+
+Never ask `cm_show` for originals. Never paste download URLs into the chat.
+
+Useful query bits (in `q` / `tags` / `type`): `filter`, `tag`, `type:decision`, `#0016` / `id:0016`. Bare word `decision` is full-text, not a type filter. `all` does not leak other shelves. An extra key’s `all` is only the shelves on that key’s grants. Pass `shelf=` / `library=` / `cwd=` when the Bearer can open more than one shelf. Isolation: **one key = its grants**. The owner's agent Bearer is the **default** key (`*` = every shelf).
+
+| Situation | Do |
+|-----------|-----|
+| Session start | `cm_health` + `cm_ambient` (never a stale `.ambient.md`). Then refresh Skill if published `version` is newer |
+| Why we chose X | `cm_search` (decision) |
+| What we know | `cm_search` + lessons / `tags` |
+| Human wants the file | tell them Dashboard Download Original |
+| Durable work just finished | pick a **named** shelf (or `cm_library`), then one MCP sweep **this turn** — never Inbox |
+| Inbox leftover | `cm_inbox`; `apply` high-confidence; `cm_classify` the rest (default may `cm_library`) — do not leave for the human |
+| Structured corpus (`corpus=slug`) | `library=` that slug; `cm_search` then `cm_show` the **card**, not a dump page |
+
+Empty ambient + Work/Ops → do not deep-search; execute, then sweep this turn.
+
+## Skill refresh (once per chat)
+
+Guests install from GitHub, not from the librarian disk. `cm_health` `min_skill` is the HTTP floor. `skill_latest` is the published Skill (env `CENTRICMEM_SKILL_LATEST` on the librarian) — it is **never** the hub’s `skills/centricmem-agent/SKILL.md`.
+
+1. Read `version` from this Skill’s frontmatter (`metadata.version`).
+2. `latest` = JSON `skill_latest` if present, else `metadata.version` at `https://raw.githubusercontent.com/zeyu-j/centricmem-skill/main/skills/centricmem-agent/SKILL.md`.
+3. If `latest` is newer: `npx --yes skills add zeyu-j/centricmem-skill --skill centricmem-agent -g -y`. Say once: on disk now; this chat still uses the loaded copy.
+4. If this file is newer, or the fetch/npx fails: continue. Do not `setup --install-skill`.
+
+## Writes (one sweep as soon as Non-Micro work exists)
+
+Hold half-finished thoughts. When the chunk is done, file **before you stop talking**. Closing the agent does not run this Skill. Do not wait for session end or for the human to say wrap up.
+
+| Type | When | MCP |
+|------|------|------|
+| Transcript | Each Non-Micro sweep | Shell-read jsonl → `cm_keep` filename + bytes (MCP does sign+PUT) |
+| Session | Same sweep | `cm_done` with `attach` |
+| Knowledge | durable model / fact | `cm_note` |
+| Decision | architecture or durable host fact | `cm_log_decision` |
+| Original | a file worth keeping | `cm_keep` as above. Never `path=`. Never Inbox |
+| Shelf | none of the named shelves fit | `cm_library` `{id}` (default key). Extra: authenticate so they enter the **default** key. Connect does not mint a shelf |
+| Bundle | capture import | `cm_import` with `library=` |
+| Inbox leftover | drain into a named shelf | `cm_classify` |
+| Index | after bulk import | `cm_index` |
+
+Later sweeps in the same chat are OK for **new** facts. Do not re-file the same decision.
+
+Do not send `path=` for the librarian to open a server file. Mention `#NNNN` in a decision body when linking units.
+
+Cursor already writes `~/.cursor/projects/<workspace>/agent-transcripts/<uuid>/<uuid>.jsonl`. Shell-read it; never paste jsonl; never delete that local file.
+
+Other agents: only keep a transcript if that runtime actually writes a local file. If there is no file, say so; do not invent a dump.
+
+## Do not
+
+- Curl librarian HTTP (or CLI `note` / `keep` / `done`) when MCP is the Skill path
+- Wait for 收尾 / close / wrap up / "log this" before filing finished Non-Micro work
+- `setup --bootstrap` on a guest machine
+- Uninstall Cursor memories or write back into them
+- Put secrets in cards
+- Load attach originals into the chat
+- Treat this git checkout as the memory disk
+- Write Inbox / `unclassified` — pick or create a named shelf

--- a/skills/centricmem-agent/SKILL.md
+++ b/skills/centricmem-agent/SKILL.md
@@ -1,32 +1,27 @@
 ---
 name: centricmem-agent
-description: "Organises and retrieves Markdown memory on the hosted CentricMem librarian via host MCP (search, notes, decisions, transcripts). Use when starting a session, filing Non-Micro work, searching project memory, connecting an agent key, or refreshing this Skill. Never write Inbox, never curl librarian HTTP, never paste keys in chat."
-compatibility: "Requires host MCP at https://mem.centricmem.com/mcp (or stdio centricmem-host). CLI >=0.21.14 for connect --device."
+description: "Organises and retrieves Markdown memory on the hosted CentricMem librarian via host MCP (search, notes, decisions, transcripts). Use when starting a session, filing Non-Micro work, searching project memory, connecting an agent key, or refreshing this Skill. Named shelves only, never curl librarian HTTP, never paste keys in chat."
+license: PolyForm-Noncommercial-1.0.0
+compatibility: "Requires host MCP at https://mem.centricmem.com/mcp (or stdio centricmem-host). CLI >=0.21.25 so guest --install-skill does not rewrite MCP."
 metadata:
-  version: "0.21.27"
-  compatible_cli: ">=0.21.14"
+  version: "0.21.33"
+  compatible_cli: ">=0.21.25"
   changelog_url: https://github.com/zeyu-j/centricmem-skill/blob/main/CHANGELOG.md
-  category: development
-  source:
-    repository: 'https://github.com/zeyu-j/centricmem-skill'
-    path: skills/centricmem-agent
-    license_path: LICENSE
-    ref: main
-    commit: 284ddb5e02cff752efb6feb4d2702f217d1fb66c
 ---
 
-# CentricMem Agent Skill v0.21.27
+# CentricMem Agent Skill v0.21.33
 
-Glossary: **Library** (one per person) → **Shelf** (pass `shelf=<id>` or `library=<id>`) → **Card** (Markdown: Identity / Details / Tags / Body, [REFERENCE.md](REFERENCE.md)). Inbox is a system shelf, never a sweep target.
+Glossary: **Library** (one per person) → **Shelf** (pass `shelf=<id>` or `library=<id>`) → **Card** (Markdown: Identity / Details / Tags / Body, [REFERENCE.md](REFERENCE.md)). There is no Inbox. Do not mint `unclassified`.
 
-CentricMem is the **manager layer** (organise / retrieve / cross-agent store) **and** the literature database. Session capture stays in the agent's own memory (Cursor memories and other plugins). Do not uninstall those. Do not write back into them. New literature: keep the original, read it, write Markdown cards. Isolation is **one key = its grants**. Default key (`*` = every shelf): search, sweep, `cm_library`, drain Inbox, mint/rename/grant/revoke extras. Extra keys open the shelves granted (one or more). Pass `shelf=` / `library=` / `cwd=` so writes route. Tags stay about. The librarian is the only writer. Login uniquely owns delete and billing. Attachments are metered per plan; Markdown is unlimited.
+CentricMem is the **manager layer** (organise / retrieve / cross-agent store) **and** the literature database. Session capture stays in the agent's own memory (Cursor memories and other plugins). Do not uninstall those. Do not write back into them. New literature: keep the original, read it, write Markdown cards. Isolation is **one key = its grants**. Default key (`*` = every shelf): search, sweep, `cm_library`, `cm_copy`, `cm_delete`, mint/rename/grant/revoke extras. Extra keys open the shelves granted (one or more) and may `cm_copy` if both grants. Pass `shelf=` / `library=` / `cwd=` so writes route. Tags stay about. The librarian is the only writer. Login uniquely owns **card** delete, billing, and rotating the default key. Humans rename a shelf **label** and browse every card on the Library desk (`/app`); the id stays. `cm_library` `{id, displayName}` on an existing shelf updates that label. Attachments are metered per plan; Markdown is unlimited.
 
 ## 0. Reach the librarian
 
-1. **MCP only.** Same `cm_*` tools whether the agent points at `https://mem.centricmem.com/mcp` (Bearer: default key or an extra key) or at stdio `centricmem-host`: `cm_health` `cm_ambient` `cm_doctor` `cm_search` `cm_show` `cm_note` `cm_log_decision` `cm_done` `cm_keep` `cm_library` `cm_inbox` `cm_import` `cm_classify` `cm_index`. Never curl librarian HTTP. Never CLI `note`/`keep`/`done`. Never `setup --bootstrap`. Never create a hub in the git checkout.
+1. **MCP only.** Same `cm_*` tools whether the agent points at `https://mem.centricmem.com/mcp` (Bearer: default key or an extra key) or at stdio `centricmem-host`: `cm_health` `cm_ambient` `cm_doctor` `cm_search` `cm_show` `cm_note` `cm_log_decision` `cm_done` `cm_keep` `cm_library` `cm_copy` `cm_delete` `cm_import` `cm_index`. Never curl librarian HTTP. Never CLI `note`/`keep`/`done`. Never `setup --bootstrap`. Never create a hub in the git checkout.
 2. If those tools are **missing**, or this chat is an extra key and the owner needs every shelf, or they need to add this librarian to the agent: **send the authenticate link**. Never ask them to paste the key here. Never one-click install. Never copy JSON into chat. Do not curl. Do not invent a hub. Keep working in the agent’s own memory.
    Run `centricmem connect --device`. Send **only** the printed URL (`/connect?device=…`). Never the device secret. They have ten minutes to enter the key. Then a new chat.
    They enter **the key they want** on that page (default = every shelf, or an extra key = granted shelves). Humans sign in at the website for the dashboard — do not send a loopback `/connect`.
+   Guest `setup --install-skill` copies Skill files only (CLI >=0.21.25). It must not rewrite Host MCP from leftover catalog. If this chat 401s after an older CLI did that, send a new authenticate link; **this chat keeps the old Bearer**.
 3. `cm_show` is the Markdown **card**. Never original=. Never paste `/download`. `cm_health` `r2=true` means originals sit in object storage. `cm_health` `scope=grant` with `grants=["*"]` is the default key — manage every shelf; extras list their shelves. Owner stuck on an extra key: send the authenticate link (step 2); **this chat keeps the old Bearer**. Pass `shelf=` / `library=` / `cwd=` so writes route. Corpus = that shelf’s key or grant. If `ACADEMIC.md` exists next to this file, follow it.
 
 ## 1. Classify
@@ -38,35 +33,41 @@ CentricMem is the **manager layer** (organise / retrieve / cross-agent store) **
 
 ## 2. Start
 
-`cm_health` then `cm_ambient`. Ignore a stale `.ambient.md`. Unreachable or `state=UNINITIALIZED`: **say once** — do not bootstrap. Writes need a **named shelf** — never Inbox / `unclassified`, even when `cwd_project=(unlinked)`. `corpus=<slug>` → `library=` that slug. Never treat ambient **text** “Skill outdated” as truth (librarian hub copy). This file is the installed `centricmem-agent` Skill (path depends on the agent).
+`cm_health` then `cm_ambient`. Ignore a stale `.ambient.md`. Unreachable or `state=UNINITIALIZED`: **say once** — do not bootstrap. Writes need a **named shelf** (`shelf=` / `library=` / cwd-link). Unlinked cwd is not a shelf — mint one (`cm_library`) or pick from `libraries=`. `corpus=<slug>` → `library=` that slug. Never treat ambient **text** “Skill outdated” as truth (librarian hub copy). This file is the installed `centricmem-agent` Skill. The folder name is the same on every agent (`~/.cursor/skills/centricmem-agent`, `~/.claude/skills/`, `~/.codex/skills/`, `~/.kiro/skills/`, `~/.kilo/skills/`, Copilot `.github/skills/`, and the rest). Plugin clients may also load the same GitHub repo as an [Agent Plugins](https://agent-plugins.org) package (`plugin.json` + `skills/` + `mcp.json`).
 
-**Once this chat, after health/ambient:** compare this file’s `metadata.version` to `skill_latest` on `cm_health` / `cm_ambient`. If that field is null, GET `https://raw.githubusercontent.com/zeyu-j/centricmem-skill/main/skills/centricmem-agent/SKILL.md` and parse `metadata.version`. If published is newer: `npx --yes skills add zeyu-j/centricmem-skill --skill centricmem-agent -g -y`. Tell the human it is on disk; **this chat still uses the already-loaded Skill**; the next chat uses the new one. If this file is newer, or fetch/npx fails: continue. Never `setup --install-skill` for this refresh.
+**Once this chat, after health/ambient:** compare this file’s `metadata.version` to `skill_latest` on `cm_health` / `cm_ambient`. If that field is null, GET `https://raw.githubusercontent.com/zeyu-j/centricmem-skill/main/skills/centricmem-agent/SKILL.md` and parse `metadata.version`. If published is newer: refresh **SKILL.md** with `npx --yes skills add zeyu-j/centricmem-skill --skill centricmem-agent -g -y` (skills.sh / SkillKit / Cursor / Claude / Codex / Kiro / Kilo / Copilot skill dirs). If this session loaded the **plugin** bundle instead, also tell them to update via that client (`/plugin`, Codex plugins UI, Copilot plugin, Kiro Powers re-import from `https://github.com/zeyu-j/centricmem-skill`). Tell the human it is on disk; **this chat still uses the already-loaded Skill**; the next chat uses the new one. If this file is newer, or fetch/npx fails: continue. Never `setup --install-skill` for this refresh. Never paste marketplace JSON into chat.
 
-**Once after Skill install / first ambient this chat:** tell the human how they use it (their language). They keep talking here. They do **not** have to say 收尾 / wrap up / log this. You file when the work is real, before you stop — closing the tab does not run this Skill. Cursor memories stay. They do not paste chats, tokens, or CLI. They search via you or log in to download originals. "Don't log" skips that sweep.
+**Once after Skill install / first ambient this chat:** tell the human how they use it (their language). They keep talking here. They do **not** have to say 收尾 / wrap up / log this. You file when the work is real, before you stop — closing the tab does not run this Skill. The agent’s own memories stay (do not uninstall them). They do not paste chats, tokens, or CLI. If they pasted a key into a chat, they sign in and **rotate** it on Keys — the old secret dies; a copy box appears at the **top** of Agent keys with the new secret (once). They enter that on a `/connect?device=` page, never here. They search via you or log in to download originals. "Don't log" skips that sweep.
 
 ## 3. During the session
 
 `cm_search` / `cm_show` / `cm_ambient` while working. Hold half-finished thoughts. **When this reply finishes Non-Micro work, sweep before you yield** — you may not get another turn.
 
-Corpus: `cm_search` (`q`, `tags`, `type` — REFERENCE). L0 snippet → L1 `cm_show` the card. Attach files are not in FTS. If the human asks to **see the original**, tell them Dashboard Download Original — **do not** load the file into this chat. Never store secrets.
+Corpus: `cm_search` (`q`, `tags`, `type` — REFERENCE). Omit `q` and pass `shelf=` to list cards on that shelf. L0 snippet → L1 `cm_show` the card. Attach files are not in FTS. If the human asks to **see the original**, tell them Dashboard Download Original — **do not** load the file into this chat. Never store secrets.
 
-New literature: **`cm_keep`** (MCP signs + PUT when `r2`) → read from the card / a human-opened file → write cards. Cursor memories are not the literature store.
+New literature: **`cm_keep`** (MCP signs + PUT when `r2`) → read from the card / a human-opened file → write cards. The agent’s own memories are not the literature store.
 
 ## 4. Sweep (Non-Micro) = one batch, as soon as the work exists
 
 Do **not** wait for 收尾, close, wrap up, "log this", session end, or a later message. Runtime hooks (`sessionEnd`) are a backup and often never fire. Closing the agent does not run this file.
 
-Human says don't log → skip. MCP missing or librarian down: skip, say once.
+Human says don't log, or they said they are **done with this Skill / CentricMem** → skip, do not accumulate.
 
-**Shelf first — never Inbox.** Ambient `libraries=` may still list `unclassified`; skip it. Pick:
+MCP missing, librarian down, or token failed: **do not drop the record.** Compose the sweep this turn (named shelf id, note / decision / done bodies, this chat's transcript path). Persist it in **this agent’s own memory** titled `CentricMem deferred sweep` (no secrets, no keys). Send the authenticate link once (step 0.2). Keep working. Do not bootstrap, curl, or CLI-write. Closing the tab still does not file — the hold is so a later connected chat can.
+
+When `cm_health` succeeds this chat: file this chat's Non-Micro batch, then file every **CentricMem deferred sweep** still in this agent’s memory (`cm_keep` those transcript paths from disk, then cards with `attach`). Same named-shelf rules. Do not ingest every transcript in the folder — only this chat and held sweeps.
+
+**Named shelf.** Ambient never reports `unclassified`. Pick:
 
 1. cwd linked, or `corpus=<slug>` → that shelf
-2. work belongs in an existing named shelf on that list → that id
-3. none fit → default key: `cm_library` `{id}` (slug like `my-project`) then file there. Extra key, or `cm_library` missing: send the authenticate link (step 0.2) so they enter the **default** key to mint a shelf (Connect does not create shelves); **hold the sweep in agent memory**. Do not write `unclassified`.
+2. work belongs in an existing named shelf on `libraries=` → that id
+3. none fit → default key: `cm_library` `{id}` (slug like `my-project`) then file there. Extra key, or `cm_library` missing: send the authenticate link (step 0.2) so they enter the **default** key to mint a shelf (Connect does not create shelves); **hold the sweep in agent memory**. Writes without a named shelf are 400 `LIBRARY_REQUIRED`.
 
 Then, with `shelf=` / `library=` that id:
 
-1. **Transcript → R2.** Cursor: `~/.cursor/projects/<workspace>/agent-transcripts/<uuid>/<uuid>.jsonl` for **this** chat. Shell-read the file; **never paste jsonl**. `cm_keep` with that filename + file bytes (never `path=`). Leave the local jsonl in place (do not delete Cursor chat state).
+1. **Transcript → R2.** If this runtime wrote a local transcript for **this** chat, Shell-read it; **never paste** it. `cm_keep` with that filename + file bytes (never `path=`). Leave the local file in place (do not delete chat state). Cursor: `~/.cursor/projects/<workspace>/agent-transcripts/<uuid>/<uuid>.jsonl`. Claude Code, Codex, Kiro, Kilo, Copilot, and the rest: only if that agent actually wrote a file. No file → skip transcript keep; still file note / decision / done.
 2. Then `cm_note` `cm_log_decision` `cm_done` with `attach` = that keep pointer. **One sweep, one batch.** If they keep talking, another sweep is OK for **new** facts — do not re-file the same decision.
 
-Existing Inbox leftovers: `cm_inbox`; `apply=true` high-confidence; remaining `cm_classify` into an existing named shelf, or default `cm_library` then classify. Do not leave leftovers for the human. If this key cannot see Inbox, say once.
+Leftover `unclassified` on an old hub: dest must exist (`cm_library` if needed). `cm_copy` `{from:unclassified,to:<named>}` (identical skip; collisions `imported/kept/from-unclassified/`). Then `cm_delete` `{id:unclassified}`. Never copy **to** Inbox. Never download originals to this computer. Extra keys may copy if both grants; only default/login may delete a leftover shelf. Card delete stays login-only.
+
+Organize leftover named shelves the same way: `cm_copy` `{from,to}` then `cm_delete` `{id}` — this **deletes** the leftover shelf (no restore warehouse).

--- a/skills/centricmem-agent/SKILL.md
+++ b/skills/centricmem-agent/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: centricmem-agent
+description: >-
+  Organises and retrieves Markdown memory on the hosted CentricMem librarian via
+  host MCP (search, notes, decisions, transcripts). Use when starting a session,
+  filing Non-Micro work, searching project memory, connecting an agent key, or
+  refreshing this Skill. Never write Inbox, never curl librarian HTTP, never
+  paste keys in chat.
+license: PolyForm-Noncommercial-1.0.0
+compatibility: >-
+  Requires host MCP at https://mem.centricmem.com/mcp (or stdio
+  centricmem-host). CLI >=0.21.14 for connect --device.
+metadata:
+  version: 0.21.26
+  compatible_cli: '>=0.21.14'
+  changelog_url: 'https://github.com/zeyu-j/centricmem-skill/blob/main/CHANGELOG.md'
+  category: development
+  source:
+    repository: 'https://github.com/zeyu-j/centricmem-skill'
+    path: skills/centricmem-agent
+    license_path: LICENSE
+    ref: main
+    commit: 299c6f0c32bf7cb32cb70de2bbb87c2f135d8517
+---
+
+# CentricMem Agent Skill v0.21.26
+
+Glossary: **Library** (one per person) → **Shelf** (pass `shelf=<id>` or `library=<id>`) → **Card** (Markdown: Identity / Details / Tags / Body, [REFERENCE.md](REFERENCE.md)). Inbox is a system shelf, never a sweep target.
+
+CentricMem is the **manager layer** (organise / retrieve / cross-agent store) **and** the literature database. Session capture stays in the agent's own memory (Cursor memories and other plugins). Do not uninstall those. Do not write back into them. New literature: keep the original, read it, write Markdown cards. Isolation is **one key = its grants**. Default key (`*` = every shelf): search, sweep, `cm_library`, drain Inbox, mint/rename/grant/revoke extras. Extra keys open the shelves granted (one or more). Pass `shelf=` / `library=` / `cwd=` so writes route. Tags stay about. The librarian is the only writer. Login uniquely owns delete and billing. Attachments are metered per plan; Markdown is unlimited.
+
+## 0. Reach the librarian
+
+1. **MCP only.** Same `cm_*` tools whether the agent points at `https://mem.centricmem.com/mcp` (Bearer: default key or an extra key) or at stdio `centricmem-host`: `cm_health` `cm_ambient` `cm_doctor` `cm_search` `cm_show` `cm_note` `cm_log_decision` `cm_done` `cm_keep` `cm_library` `cm_inbox` `cm_import` `cm_classify` `cm_index`. Never curl librarian HTTP. Never CLI `note`/`keep`/`done`. Never `setup --bootstrap`. Never create a hub in the git checkout.
+2. If those tools are **missing**, or this chat is an extra key and the owner needs every shelf, or they need to add this librarian to the agent: **send the authenticate link**. Never ask them to paste the key here. Never one-click install. Never copy JSON into chat. Do not curl. Do not invent a hub. Keep working in the agent’s own memory.
+   Run `centricmem connect --device`. Send **only** the printed URL (`/connect?device=…`). Never the device secret. They have ten minutes to enter the key. Then a new chat.
+   They enter **the key they want** on that page (default = every shelf, or an extra key = granted shelves). Humans sign in at the website for the dashboard — do not send a loopback `/connect`.
+3. `cm_show` is the Markdown **card**. Never original=. Never paste `/download`. `cm_health` `r2=true` means originals sit in object storage. `cm_health` `scope=grant` with `grants=["*"]` is the default key — manage every shelf; extras list their shelves. Owner stuck on an extra key: send the authenticate link (step 2); **this chat keeps the old Bearer**. Pass `shelf=` / `library=` / `cwd=` so writes route. Corpus = that shelf’s key or grant. If `ACADEMIC.md` exists next to this file, follow it.
+
+## 1. Classify
+
+| Skip (Micro) | Sweep this turn (Non-Micro) |
+|---|---|
+| Typo, one-liner, trivial syntax, no durable fact | Implement, ops, research, architecture, corpus lookup, a product/host decision |
+| | Same thread ≥2 real turns **or** one turn that shipped or decided something |
+
+## 2. Start
+
+`cm_health` then `cm_ambient`. Ignore a stale `.ambient.md`. Unreachable or `state=UNINITIALIZED`: **say once** — do not bootstrap. Writes need a **named shelf** — never Inbox / `unclassified`, even when `cwd_project=(unlinked)`. `corpus=<slug>` → `library=` that slug. Never treat ambient **text** “Skill outdated” as truth (librarian hub copy). This file is `~/.cursor/skills/centricmem-agent/SKILL.md`.
+
+**Once this chat, after health/ambient:** compare this file’s `version` to `skill_latest` on `cm_health` / `cm_ambient`. If that field is null, GET `https://raw.githubusercontent.com/zeyu-j/centricmem-skill/main/skills/centricmem-agent/SKILL.md` and parse `version`. If published is newer: `npx --yes skills add zeyu-j/centricmem-skill --skill centricmem-agent -g -y`. Tell the human it is on disk; **this chat still uses the already-loaded Skill**; the next chat uses the new one. If this file is newer, or fetch/npx fails: continue. Never `setup --install-skill` for this refresh.
+
+**Once after Skill install / first ambient this chat:** tell the human how they use it (their language). They keep talking here. They do **not** have to say 收尾 / wrap up / log this. You file when the work is real, before you stop — closing the tab does not run this Skill. Cursor memories stay. They do not paste chats, tokens, or CLI. They search via you or log in to download originals. "Don't log" skips that sweep.
+
+## 3. During the session
+
+`cm_search` / `cm_show` / `cm_ambient` while working. Hold half-finished thoughts. **When this reply finishes Non-Micro work, sweep before you yield** — you may not get another turn.
+
+Corpus: `cm_search` (`q`, `tags`, `type` — REFERENCE). L0 snippet → L1 `cm_show` the card. Attach files are not in FTS. If the human asks to **see the original**, tell them Dashboard Download Original — **do not** load the file into this chat. Never store secrets.
+
+New literature: **`cm_keep`** (MCP signs + PUT when `r2`) → read from the card / a human-opened file → write cards. Cursor memories are not the literature store.
+
+## 4. Sweep (Non-Micro) = one batch, as soon as the work exists
+
+Do **not** wait for 收尾, close, wrap up, "log this", session end, or a later message. Runtime hooks (`sessionEnd`) are a backup and often never fire. Closing the agent does not run this file.
+
+Human says don't log → skip. MCP missing or librarian down: skip, say once.
+
+**Shelf first — never Inbox.** Ambient `libraries=` may still list `unclassified`; skip it. Pick:
+
+1. cwd linked, or `corpus=<slug>` → that shelf
+2. work belongs in an existing named shelf on that list → that id
+3. none fit → default key: `cm_library` `{id}` (slug like `my-project`) then file there. Extra key, or `cm_library` missing: send the authenticate link (step 0.2) so they enter the **default** key to mint a shelf (Connect does not create shelves); **hold the sweep in agent memory**. Do not write `unclassified`.
+
+Then, with `shelf=` / `library=` that id:
+
+1. **Transcript → R2.** Cursor: `~/.cursor/projects/<workspace>/agent-transcripts/<uuid>/<uuid>.jsonl` for **this** chat. Shell-read the file; **never paste jsonl**. `cm_keep` with that filename + file bytes (never `path=`). Leave the local jsonl in place (do not delete Cursor chat state).
+2. Then `cm_note` `cm_log_decision` `cm_done` with `attach` = that keep pointer. **One sweep, one batch.** If they keep talking, another sweep is OK for **new** facts — do not re-file the same decision.
+
+Existing Inbox leftovers: `cm_inbox`; `apply=true` high-confidence; remaining `cm_classify` into an existing named shelf, or default `cm_library` then classify. Do not leave leftovers for the human. If this key cannot see Inbox, say once.

--- a/skills/centricmem-agent/SKILL.md
+++ b/skills/centricmem-agent/SKILL.md
@@ -1,29 +1,21 @@
 ---
 name: centricmem-agent
-description: >-
-  Organises and retrieves Markdown memory on the hosted CentricMem librarian via
-  host MCP (search, notes, decisions, transcripts). Use when starting a session,
-  filing Non-Micro work, searching project memory, connecting an agent key, or
-  refreshing this Skill. Never write Inbox, never curl librarian HTTP, never
-  paste keys in chat.
-license: PolyForm-Noncommercial-1.0.0
-compatibility: >-
-  Requires host MCP at https://mem.centricmem.com/mcp (or stdio
-  centricmem-host). CLI >=0.21.14 for connect --device.
+description: "Organises and retrieves Markdown memory on the hosted CentricMem librarian via host MCP (search, notes, decisions, transcripts). Use when starting a session, filing Non-Micro work, searching project memory, connecting an agent key, or refreshing this Skill. Never write Inbox, never curl librarian HTTP, never paste keys in chat."
+compatibility: "Requires host MCP at https://mem.centricmem.com/mcp (or stdio centricmem-host). CLI >=0.21.14 for connect --device."
 metadata:
-  version: 0.21.26
-  compatible_cli: '>=0.21.14'
-  changelog_url: 'https://github.com/zeyu-j/centricmem-skill/blob/main/CHANGELOG.md'
+  version: "0.21.27"
+  compatible_cli: ">=0.21.14"
+  changelog_url: https://github.com/zeyu-j/centricmem-skill/blob/main/CHANGELOG.md
   category: development
   source:
     repository: 'https://github.com/zeyu-j/centricmem-skill'
     path: skills/centricmem-agent
     license_path: LICENSE
     ref: main
-    commit: 299c6f0c32bf7cb32cb70de2bbb87c2f135d8517
+    commit: 284ddb5e02cff752efb6feb4d2702f217d1fb66c
 ---
 
-# CentricMem Agent Skill v0.21.26
+# CentricMem Agent Skill v0.21.27
 
 Glossary: **Library** (one per person) → **Shelf** (pass `shelf=<id>` or `library=<id>`) → **Card** (Markdown: Identity / Details / Tags / Body, [REFERENCE.md](REFERENCE.md)). Inbox is a system shelf, never a sweep target.
 
@@ -46,9 +38,9 @@ CentricMem is the **manager layer** (organise / retrieve / cross-agent store) **
 
 ## 2. Start
 
-`cm_health` then `cm_ambient`. Ignore a stale `.ambient.md`. Unreachable or `state=UNINITIALIZED`: **say once** — do not bootstrap. Writes need a **named shelf** — never Inbox / `unclassified`, even when `cwd_project=(unlinked)`. `corpus=<slug>` → `library=` that slug. Never treat ambient **text** “Skill outdated” as truth (librarian hub copy). This file is `~/.cursor/skills/centricmem-agent/SKILL.md`.
+`cm_health` then `cm_ambient`. Ignore a stale `.ambient.md`. Unreachable or `state=UNINITIALIZED`: **say once** — do not bootstrap. Writes need a **named shelf** — never Inbox / `unclassified`, even when `cwd_project=(unlinked)`. `corpus=<slug>` → `library=` that slug. Never treat ambient **text** “Skill outdated” as truth (librarian hub copy). This file is the installed `centricmem-agent` Skill (path depends on the agent).
 
-**Once this chat, after health/ambient:** compare this file’s `version` to `skill_latest` on `cm_health` / `cm_ambient`. If that field is null, GET `https://raw.githubusercontent.com/zeyu-j/centricmem-skill/main/skills/centricmem-agent/SKILL.md` and parse `version`. If published is newer: `npx --yes skills add zeyu-j/centricmem-skill --skill centricmem-agent -g -y`. Tell the human it is on disk; **this chat still uses the already-loaded Skill**; the next chat uses the new one. If this file is newer, or fetch/npx fails: continue. Never `setup --install-skill` for this refresh.
+**Once this chat, after health/ambient:** compare this file’s `metadata.version` to `skill_latest` on `cm_health` / `cm_ambient`. If that field is null, GET `https://raw.githubusercontent.com/zeyu-j/centricmem-skill/main/skills/centricmem-agent/SKILL.md` and parse `metadata.version`. If published is newer: `npx --yes skills add zeyu-j/centricmem-skill --skill centricmem-agent -g -y`. Tell the human it is on disk; **this chat still uses the already-loaded Skill**; the next chat uses the new one. If this file is newer, or fetch/npx fails: continue. Never `setup --install-skill` for this refresh.
 
 **Once after Skill install / first ambient this chat:** tell the human how they use it (their language). They keep talking here. They do **not** have to say 收尾 / wrap up / log this. You file when the work is real, before you stop — closing the tab does not run this Skill. Cursor memories stay. They do not paste chats, tokens, or CLI. They search via you or log in to download originals. "Don't log" skips that sweep.
 


### PR DESCRIPTION
## Summary

- Adds `skills/centricmem-agent` via `npx tsx bin/add-remote-skill.ts https://github.com/zeyu-j/centricmem-skill/tree/main/skills/centricmem-agent`
- Source: https://github.com/zeyu-j/centricmem-skill (`skills/centricmem-agent`, commit `299c6f0c32bf7cb32cb70de2bbb87c2f135d8517`)
- Category set to `development`; `metadata.source.license_path` is `LICENSE`

## What problem it solves

Agents keep session capture in their own memory. When work is real they need a shared organise/retrieve layer: Markdown cards (notes, decisions, transcripts) on one hosted librarian, searchable later by any connected agent. CentricMem is that librarian. Host MCP is `https://mem.centricmem.com/mcp`. Humans authenticate with a ten-minute `/connect?device=` link so keys never land in chat.

## Who uses this workflow

Anyone running Kilo Code (or another Agent Skills client) against a hosted CentricMem library. Install remains `npx skills add zeyu-j/centricmem-skill --skill centricmem-agent -g`.

## License

Canonical license is **PolyForm-Noncommercial-1.0.0** (repo-root `LICENSE`). This is not Apache 2.0. The marketplace copy is an index; the source repo stays canonical.

## Test plan

- [ ] Confirm `SKILL.md` frontmatter has `metadata.source.repository`, `path`, `license_path`, `commit`
- [ ] Open https://github.com/zeyu-j/centricmem-skill/tree/main/skills/centricmem-agent
- [ ] Install the Skill and reach host MCP after `/connect?device=` (do not paste keys into the PR or chat)

Made with [Cursor](https://cursor.com)