### PR TITLE
Add Contracko remote MCP server

### DIFF
--- a/mcps/contracko/MCP.yaml
+++ b/mcps/contracko/MCP.yaml
@@ -1,0 +1,17 @@
+id: contracko
+name: Contracko
+description: Contract management for your workspace. Import contracts, read extracted parties, dates and values,
+  search inside documents, run AI analysis, and track renewal deadlines and reminders.
+author: contracko
+url: https://github.com/contracko/contracko-skills
+category: business
+content:
+  - name: Remote Server
+    content: |
+      {
+        "type": "streamable-http",
+        "url": "https://app.contracko.com/mcp"
+      }
+    prerequisites:
+      - MCP client with OAuth support
+      - A Contracko account, or start a free trial from the sign in screen

--- a/mcps/contracko/MCP.yaml
+++ b/mcps/contracko/MCP.yaml
@@ -1,7 +1,7 @@
 id: contracko
 name: Contracko
-description: Contract management for your workspace. Import contracts, read extracted parties, dates and values,
-  search inside documents, run AI analysis, and track renewal deadlines and reminders.
+description: AI contract management. Review contracts for risks and obligations, extract dates, parties and values,
+  search inside documents, and track renewal deadlines and reminders.
 author: contracko
 url: https://github.com/contracko/contracko-skills
 category: business


### PR DESCRIPTION
Adds Contracko as a remote MCP server under `mcps/contracko/MCP.yaml`.

Contracko is an AI contract management platform. It reviews contracts for risks and obligations, extracts the key data (dates, parties, values, notice periods), and tracks deadlines so nothing renews silently. The MCP server puts that workspace inside the assistant you already use, so you can ask what is expiring this quarter, pull a folder of PDFs in, or compare two agreements without leaving the chat.

- **Transport:** `streamable-http` at `https://app.contracko.com/mcp`
- **Auth:** OAuth 2.1 with PKCE and dynamic client registration, listed as a prerequisite the same way `mcps/snowflake-managed/MCP.yaml` does. Static bearer tokens also work for headless use.
- **Scopes:** read and write are separate, so you can connect read only
- **Category:** `business`
- Published in the official MCP registry as `com.contracko/contracko`
- Docs: https://contracko.com/docs/mcp-server

A free trial can be started from the sign in screen, so the server is usable without an existing account.

The linked repo also holds four skills (`contracko`, `contracko-import`, `contracko-review`, `contracko-create`). Happy to submit those separately through `bin/add-remote-skill.ts` rather than mixing two kinds of change into one PR.
